### PR TITLE
Properly convert all headers statuses returned by the WASM.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,7 +6,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "proxy_wasm_cpp_sdk",
     remote = "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk",
-    commit = "c12553951d01bb60cb1448ba1fcfeb8f843aad62",
+    commit = "96927d814b3ec14893b56793e122125e095654c7",
 )
 
 http_archive(

--- a/src/context.cc
+++ b/src/context.cc
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 #include <deque>
-#include <memory>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 #include <unordered_set>
@@ -387,11 +387,10 @@ FilterHeadersStatus ContextBase::onRequestHeaders(uint32_t headers) {
   if (!wasm_->on_request_headers_) {
     return FilterHeadersStatus::Continue;
   }
-  if (static_cast<FilterHeadersStatus>(wasm_->on_request_headers_(this, id_, headers).u64_) ==
-      FilterHeadersStatus::Continue) {
-    return FilterHeadersStatus::Continue;
-  }
-  return FilterHeadersStatus::StopIteration;
+  auto result = wasm_->on_request_headers_(this, id_, headers).u64_;
+  if (result > static_cast<uint64_t>(FilterHeadersStatus::StopAllIterationAndWatermark))
+    return FilterHeadersStatus::StopAllIterationAndWatermark;
+  return static_cast<FilterHeadersStatus>(result);
 }
 
 FilterDataStatus ContextBase::onRequestBody(uint32_t data_length, bool end_of_stream) {
@@ -443,11 +442,10 @@ FilterHeadersStatus ContextBase::onResponseHeaders(uint32_t headers) {
   if (!wasm_->on_response_headers_) {
     return FilterHeadersStatus::Continue;
   }
-  if (static_cast<FilterHeadersStatus>(wasm_->on_response_headers_(this, id_, headers).u64_) ==
-      FilterHeadersStatus::Continue) {
-    return FilterHeadersStatus::Continue;
-  }
-  return FilterHeadersStatus::StopIteration;
+  auto result = wasm_->on_response_headers_(this, id_, headers).u64_;
+  if (result > static_cast<uint64_t>(FilterHeadersStatus::StopAllIterationAndWatermark))
+    return FilterHeadersStatus::StopAllIterationAndWatermark;
+  return static_cast<FilterHeadersStatus>(result);
 }
 
 FilterDataStatus ContextBase::onResponseBody(uint32_t body_length, bool end_of_stream) {


### PR DESCRIPTION
This adds support to the new status values added by the
proxy-wasm-cpp-sdk in

https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/pull/19

It won't build until that is also merged.

Signed-off-by: Gregory Brail <gregbrail@google.com>