### PR TITLE
Add the "end_of_stream" flag to header processing.

### DIFF
--- a/include/proxy-wasm/context.h
+++ b/include/proxy-wasm/context.h
@@ -15,10 +15,8 @@
 
 #pragma once
 
-#include "include/proxy-wasm/compat.h"
-#include "include/proxy-wasm/context_interface.h"
-
 #include <time.h>
+
 #include <atomic>
 #include <chrono>
 #include <functional>
@@ -26,6 +24,9 @@
 #include <map>
 #include <memory>
 #include <vector>
+
+#include "include/proxy-wasm/compat.h"
+#include "include/proxy-wasm/context_interface.h"
 
 namespace proxy_wasm {
 
@@ -132,11 +133,11 @@ public:
   void onQueueReady(SharedQueueDequeueToken token) override;
 
   // HTTP
-  FilterHeadersStatus onRequestHeaders(uint32_t headers) override;
+  FilterHeadersStatus onRequestHeaders(uint32_t headers, bool end_of_stream) override;
   FilterDataStatus onRequestBody(uint32_t body_buffer_length, bool end_of_stream) override;
   FilterTrailersStatus onRequestTrailers(uint32_t trailers) override;
   FilterMetadataStatus onRequestMetadata(uint32_t elements) override;
-  FilterHeadersStatus onResponseHeaders(uint32_t headers) override;
+  FilterHeadersStatus onResponseHeaders(uint32_t headers, bool end_of_stream) override;
   FilterDataStatus onResponseBody(uint32_t body_buffer_length, bool end_of_stream) override;
   FilterTrailersStatus onResponseTrailers(uint32_t trailers) override;
   FilterMetadataStatus onResponseMetadata(uint32_t elements) override;

--- a/include/proxy-wasm/context_interface.h
+++ b/include/proxy-wasm/context_interface.h
@@ -223,7 +223,7 @@ public:
    * Call on a stream context to indicate that the request headers have arrived.  Calls
    * onCreate() to create a Context in the VM first.
    */
-  virtual FilterHeadersStatus onRequestHeaders(uint32_t headers) = 0;
+  virtual FilterHeadersStatus onRequestHeaders(uint32_t headers, bool end_of_stream) = 0;
 
   // Call on a stream context to indicate that body data has arrived.
   virtual FilterDataStatus onRequestBody(uint32_t body_buffer_length, bool end_of_stream) = 0;
@@ -235,7 +235,7 @@ public:
   virtual FilterMetadataStatus onRequestMetadata(uint32_t elements) = 0;
 
   // Call on a stream context to indicate that the request trailers have arrived.
-  virtual FilterHeadersStatus onResponseHeaders(uint32_t trailers) = 0;
+  virtual FilterHeadersStatus onResponseHeaders(uint32_t trailers, bool end_of_stream) = 0;
 
   // Call on a stream context to indicate that body data has arrived.
   virtual FilterDataStatus onResponseBody(uint32_t body_buffer_length, bool end_of_stream) = 0;

--- a/src/context.cc
+++ b/src/context.cc
@@ -387,7 +387,7 @@ void ContextBase::onUpstreamConnectionClose(CloseType close_type) {
 // Empty headers/trailers have zero size.
 template <typename P> static uint32_t headerSize(const P &p) { return p ? p->size() : 0; }
 
-FilterHeadersStatus ContextBase::onRequestHeaders(uint32_t headers) {
+FilterHeadersStatus ContextBase::onRequestHeaders(uint32_t headers, bool) {
   DeferAfterCallActions actions(this);
   onCreate(root_context_id_);
   in_vm_context_created_ = true;
@@ -436,7 +436,7 @@ FilterMetadataStatus ContextBase::onRequestMetadata(uint32_t elements) {
   return FilterMetadataStatus::Continue; // This is currently the only return code.
 }
 
-FilterHeadersStatus ContextBase::onResponseHeaders(uint32_t headers) {
+FilterHeadersStatus ContextBase::onResponseHeaders(uint32_t headers, bool) {
   DeferAfterCallActions actions(this);
   if (!in_vm_context_created_) {
     // If the request is invalid then onRequestHeaders() will not be called and neither will


### PR DESCRIPTION
Add the "end_of_stream" flag to onRequestHeaders and
onResponseHeaders to match the signature in Envoy. It's ignored
for new. We'll use another commit to pass this field on to WASM.

This begins to address:

https://github.com/envoyproxy/envoy-wasm/issues/446

Signed-off-by: Gregory Brail <gregbrail@google.com>