### PR TITLE
Pass end_of-stream flag to request and response headers.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,8 +5,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "proxy_wasm_cpp_sdk",
+    commit = "b273b07ae0cfa9cc76dfe38236b163e9e3a2ab49",
     remote = "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk",
-    commit = "96927d814b3ec14893b56793e122125e095654c7",
 )
 
 http_archive(
@@ -20,19 +20,21 @@ http_archive(
 # required by com_google_protobuf
 http_archive(
     name = "bazel_skylib",
+    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
         "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
-        ],
-    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
-    )
+    ],
+)
+
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
 bazel_skylib_workspace()
 
 git_repository(
     name = "com_google_protobuf",
-    remote = "https://github.com/protocolbuffers/protobuf",
     commit = "655310ca192a6e3a050e0ca0b7084a2968072260",
+    remote = "https://github.com/protocolbuffers/protobuf",
 )
 
 http_archive(

--- a/include/proxy-wasm/null_plugin.h
+++ b/include/proxy-wasm/null_plugin.h
@@ -17,10 +17,9 @@
 
 #include <memory>
 
+#include "google/protobuf/message.h"
 #include "include/proxy-wasm/null_vm_plugin.h"
 #include "include/proxy-wasm/wasm.h"
-
-#include "google/protobuf/message.h"
 
 namespace proxy_wasm {
 namespace null_plugin {
@@ -84,12 +83,12 @@ public:
   void onDownstreamConnectionClose(uint64_t context_id, uint64_t close_type);
   void onUpstreamConnectionClose(uint64_t context_id, uint64_t close_type);
 
-  uint64_t onRequestHeaders(uint64_t context_id, uint64_t headers);
+  uint64_t onRequestHeaders(uint64_t context_id, uint64_t headers, uint64_t end_of_stream);
   uint64_t onRequestBody(uint64_t context_id, uint64_t body_buffer_length, uint64_t end_of_stream);
   uint64_t onRequestTrailers(uint64_t context_id, uint64_t trailers);
   uint64_t onRequestMetadata(uint64_t context_id, uint64_t elements);
 
-  uint64_t onResponseHeaders(uint64_t context_id, uint64_t headers);
+  uint64_t onResponseHeaders(uint64_t context_id, uint64_t headers, uint64_t end_of_stream);
   uint64_t onResponseBody(uint64_t context_id, uint64_t body_buffer_length, uint64_t end_of_stream);
   uint64_t onResponseTrailers(uint64_t context_id, uint64_t trailers);
   uint64_t onResponseMetadata(uint64_t context_id, uint64_t elements);

--- a/include/proxy-wasm/wasm.h
+++ b/include/proxy-wasm/wasm.h
@@ -20,12 +20,11 @@
 #include <atomic>
 #include <deque>
 #include <map>
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
-#include <memory>
 
 #include "include/proxy-wasm/compat.h"
-
 #include "include/proxy-wasm/context.h"
 #include "include/proxy-wasm/exports.h"
 #include "include/proxy-wasm/wasm_vm.h"
@@ -206,12 +205,12 @@ protected:
   WasmCallVoid<2> on_downstream_connection_close_;
   WasmCallVoid<2> on_upstream_connection_close_;
 
-  WasmCallWord<2> on_request_headers_;
+  WasmCallWord<3> on_request_headers_;
   WasmCallWord<3> on_request_body_;
   WasmCallWord<2> on_request_trailers_;
   WasmCallWord<2> on_request_metadata_;
 
-  WasmCallWord<2> on_response_headers_;
+  WasmCallWord<3> on_response_headers_;
   WasmCallWord<3> on_response_body_;
   WasmCallWord<2> on_response_trailers_;
   WasmCallWord<2> on_response_metadata_;

--- a/src/context.cc
+++ b/src/context.cc
@@ -387,14 +387,15 @@ void ContextBase::onUpstreamConnectionClose(CloseType close_type) {
 // Empty headers/trailers have zero size.
 template <typename P> static uint32_t headerSize(const P &p) { return p ? p->size() : 0; }
 
-FilterHeadersStatus ContextBase::onRequestHeaders(uint32_t headers, bool) {
+FilterHeadersStatus ContextBase::onRequestHeaders(uint32_t headers, bool end_of_stream) {
   DeferAfterCallActions actions(this);
   onCreate(root_context_id_);
   in_vm_context_created_ = true;
   if (!wasm_->on_request_headers_) {
     return FilterHeadersStatus::Continue;
   }
-  auto result = wasm_->on_request_headers_(this, id_, headers).u64_;
+  auto result =
+      wasm_->on_request_headers_(this, id_, headers, static_cast<uint32_t>(end_of_stream)).u64_;
   if (result > static_cast<uint64_t>(FilterHeadersStatus::StopAllIterationAndWatermark))
     return FilterHeadersStatus::StopAllIterationAndWatermark;
   return static_cast<FilterHeadersStatus>(result);
@@ -436,7 +437,7 @@ FilterMetadataStatus ContextBase::onRequestMetadata(uint32_t elements) {
   return FilterMetadataStatus::Continue; // This is currently the only return code.
 }
 
-FilterHeadersStatus ContextBase::onResponseHeaders(uint32_t headers, bool) {
+FilterHeadersStatus ContextBase::onResponseHeaders(uint32_t headers, bool end_of_stream) {
   DeferAfterCallActions actions(this);
   if (!in_vm_context_created_) {
     // If the request is invalid then onRequestHeaders() will not be called and neither will
@@ -449,7 +450,8 @@ FilterHeadersStatus ContextBase::onResponseHeaders(uint32_t headers, bool) {
   if (!wasm_->on_response_headers_) {
     return FilterHeadersStatus::Continue;
   }
-  auto result = wasm_->on_response_headers_(this, id_, headers).u64_;
+  auto result =
+      wasm_->on_response_headers_(this, id_, headers, static_cast<uint32_t>(end_of_stream)).u64_;
   if (result > static_cast<uint64_t>(FilterHeadersStatus::StopAllIterationAndWatermark))
     return FilterHeadersStatus::StopAllIterationAndWatermark;
   return static_cast<FilterHeadersStatus>(result);


### PR DESCRIPTION
This propagates the end_of_stream flag to the plugin for both the header callbacks. It is an incompatible change -- modules will need to be recompiled once this is merged into Envoy.

This makes is possible for a filter to deal with request and response bodies in a generic way without having to guess whether a body is coming from the HTTP method. This is important because otherwise a filter might wait for an "on data" callback that will never come.

I'll submit the matching PRs for the other two repos once this one is merged.

Signed-off-by: Gregory Brail <gregbrail@google.com>