### PR TITLE
Begin to add support for a proxy_get_log_level ABI function

### DIFF
--- a/include/proxy-wasm/context.h
+++ b/include/proxy-wasm/context.h
@@ -229,7 +229,7 @@ public:
   WasmResult log(uint32_t /* level */, string_view /* message */) override {
     return unimplemented();
   }
-  uint32_t getLogLevel() override { return 0; }
+  uint32_t getLogLevel() override { return static_cast<uint32_t>(LogLevel::info); }
   uint64_t getCurrentTimeNanoseconds() override {
     struct timespec tpe;
     clock_gettime(CLOCK_REALTIME, &tpe);

--- a/include/proxy-wasm/context.h
+++ b/include/proxy-wasm/context.h
@@ -229,6 +229,7 @@ public:
   WasmResult log(uint32_t /* level */, string_view /* message */) override {
     return unimplemented();
   }
+  uint32_t getLogLevel() override { return 0; }
   uint64_t getCurrentTimeNanoseconds() override {
     struct timespec tpe;
     clock_gettime(CLOCK_REALTIME, &tpe);

--- a/include/proxy-wasm/context_interface.h
+++ b/include/proxy-wasm/context_interface.h
@@ -530,6 +530,9 @@ struct GeneralInterface {
   // Log a message.
   virtual WasmResult log(uint32_t level, string_view message) = 0;
 
+  // Return the current log level in the host
+  virtual uint32_t getLogLevel() = 0;
+
   /**
    * Enables a periodic timer with the given period or sets the period of an existing timer. Note:
    * the timer is associated with the Root Context of whatever Context this call was made on.

--- a/include/proxy-wasm/exports.h
+++ b/include/proxy-wasm/exports.h
@@ -31,6 +31,7 @@ namespace exports {
 
 Word get_status(void *raw_context, Word status_code, Word address, Word size);
 Word log(void *raw_context, Word level, Word address, Word size);
+Word get_log_level(void *raw_context, Word result_level_uint32_ptr);
 Word get_property(void *raw_context, Word path_ptr, Word path_size, Word value_ptr_ptr,
                   Word value_size_ptr);
 Word set_property(void *raw_context, Word key_ptr, Word key_size, Word value_ptr, Word value_size);

--- a/src/exports.cc
+++ b/src/exports.cc
@@ -837,5 +837,14 @@ Word log(void *raw_context, Word level, Word address, Word size) {
   return context->log(level, message.value());
 }
 
+Word get_log_level(void *raw_context, Word result_level_uint32_ptr) {
+  auto context = WASM_CONTEXT(raw_context);
+  uint32_t level = context->getLogLevel();
+  if (!context->wasm()->setDatatype(result_level_uint32_ptr, level)) {
+    return WasmResult::InvalidMemoryAccess;
+  }
+  return WasmResult::Ok;
+}
+
 } // namespace exports
 } // namespace proxy_wasm

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -140,6 +140,7 @@ void WasmBase::registerCallbacks() {
       &ConvertFunctionWordToUint32<decltype(exports::_fn),                                         \
                                    exports::_fn>::convertFunctionWordToUint32);
   _REGISTER_PROXY(log);
+  _REGISTER_PROXY(get_log_level);
 
   _REGISTER_PROXY(get_status);
 


### PR DESCRIPTION
The intent of this function is to return the current log level
in the host. This way, WASM modules can avoid calling proxy_log
at all for certain log levels if they are sure that nothing
will be logged.

This will be important in WASM modules that wish to support "debug"
and "trace" logging but which also want to reduce the cost of
generating log messages that will never be output.

If this makes sense to you all then I'll make the appropriate changes
in the SDK and in envoy-wasm too.

Signed-off-by: Gregory Brail <gregbrail@google.com>