### PR TITLE
Move get_log_level to ABI version 0.2.1

### DIFF
--- a/include/proxy-wasm/wasm_vm.h
+++ b/include/proxy-wasm/wasm_vm.h
@@ -101,7 +101,7 @@ enum class Cloneable {
   InstantiatedModule // VMs can be cloned from an instantiated module.
 };
 
-enum class AbiVersion { ProxyWasm_0_1_0, ProxyWasm_0_2_0, Unknown };
+enum class AbiVersion { ProxyWasm_0_1_0, ProxyWasm_0_2_0, ProxyWasm_0_2_1, Unknown };
 
 class NullPlugin;
 

--- a/src/null/null_vm.cc
+++ b/src/null/null_vm.cc
@@ -57,7 +57,7 @@ bool NullVm::load(const std::string &name, bool /* allow_precompiled */) {
   return true;
 }
 
-AbiVersion NullVm::getAbiVersion() { return AbiVersion::ProxyWasm_0_2_0; }
+AbiVersion NullVm::getAbiVersion() { return AbiVersion::ProxyWasm_0_2_1; }
 
 bool NullVm::link(std::string_view /* name */) { return true; }
 

--- a/src/v8/v8.cc
+++ b/src/v8/v8.cc
@@ -378,6 +378,8 @@ AbiVersion V8::getAbiVersion() {
         return AbiVersion::ProxyWasm_0_1_0;
       } else if (name == "proxy_abi_version_0_2_0") {
         return AbiVersion::ProxyWasm_0_2_0;
+      } else if (name == "proxy_abi_version_0_2_1") {
+        return AbiVersion::ProxyWasm_0_2_1;
       }
     }
   }

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -250,7 +250,8 @@ void WasmBase::getFunctions() {
   if (abiVersion() == AbiVersion::ProxyWasm_0_1_0) {
     _GET_PROXY_ABI(on_request_headers, _abi_01);
     _GET_PROXY_ABI(on_response_headers, _abi_01);
-  } else if (abiVersion() == AbiVersion::ProxyWasm_0_2_0) {
+  } else if (abiVersion() == AbiVersion::ProxyWasm_0_2_0 ||
+             abiVersion() == AbiVersion::ProxyWasm_0_2_1) {
     _GET_PROXY_ABI(on_request_headers, _abi_02);
     _GET_PROXY_ABI(on_response_headers, _abi_02);
     _GET_PROXY(on_foreign_function);

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -141,7 +141,6 @@ void WasmBase::registerCallbacks() {
       &ConvertFunctionWordToUint32<decltype(exports::_fn),                                         \
                                    exports::_fn>::convertFunctionWordToUint32);
   _REGISTER_PROXY(log);
-  _REGISTER_PROXY(get_log_level);
 
   _REGISTER_PROXY(get_status);
 
@@ -198,6 +197,10 @@ void WasmBase::registerCallbacks() {
   } else if (abiVersion() == AbiVersion::ProxyWasm_0_2_0) {
     _REGISTER_PROXY(continue_stream);
     _REGISTER_PROXY(close_stream);
+  } else if (abiVersion() == AbiVersion::ProxyWasm_0_2_1) {
+    _REGISTER_PROXY(continue_stream);
+    _REGISTER_PROXY(close_stream);
+    _REGISTER_PROXY(get_log_level);
   }
 #undef _REGISTER_PROXY
 }


### PR DESCRIPTION
Add ProxyWasm_0_2_1 enum and support.

Signed-off-by: Gregory Brail <gregbrail@google.com>