### PR TITLE
Allow proxy_get_buffer_byts(0, MAX, ...).

### DIFF
--- a/src/exports.cc
+++ b/src/exports.cc
@@ -494,9 +494,13 @@ Word get_buffer_bytes(void *raw_context, Word type, Word start, Word length, Wor
   if (!buffer) {
     return WasmResult::NotFound;
   }
-  // check for overflow.
-  if (buffer->size() < start + length || start > start + length) {
+  // Check for overflow.
+  if (start > start + length) {
     return WasmResult::BadArgument;
+  }
+  // Don't overread.
+  if (start + length > buffer->size()) {
+    length = buffer->size() - start;
   }
   if (length > 0) {
     return buffer->copyTo(context->wasm(), start, length, ptr_ptr, size_ptr);


### PR DESCRIPTION
This convention is already allowed in proxy_set_buffer_bytes(),
and it was previously allowed for proxy_get_buffer_byts().

Signed-off-by: Piotr Sikora <piotrsikora@google.com>