### PR TITLE
Do not use get_clock on windows where it is not supported.

### DIFF
--- a/include/proxy-wasm/context.h
+++ b/include/proxy-wasm/context.h
@@ -231,12 +231,17 @@ public:
   }
   uint32_t getLogLevel() override { return static_cast<uint32_t>(LogLevel::info); }
   uint64_t getCurrentTimeNanoseconds() override {
+#if !defined(_MSC_VER)
     struct timespec tpe;
     clock_gettime(CLOCK_REALTIME, &tpe);
     uint64_t t = tpe.tv_sec;
     t *= 1000000000;
     t += tpe.tv_nsec;
     return t;
+#else
+    unimplemented();
+    return 0;
+#endif
   }
   std::string_view getConfiguration() override {
     unimplemented();


### PR DESCRIPTION
Signed-off-by: John Plevyak <jplevyak@gmail.com>