### PR TITLE
invoke on_context_create_ for all root contexts with a same VM ID

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -331,9 +331,15 @@ bool ContextBase::onStart(std::shared_ptr<PluginBase> plugin) {
 }
 
 bool ContextBase::onConfigure(std::shared_ptr<PluginBase> plugin) {
+  if (!in_vm_context_created_ && wasm_->on_context_create_) {
+    wasm_->on_context_create_(this, id_, 0);
+    in_vm_context_created_ = true;
+  }
+
   if (isFailed() || !wasm_->on_configure_) {
     return true;
   }
+
   DeferAfterCallActions actions(this);
   plugin_ = plugin;
   auto result =

--- a/src/context.cc
+++ b/src/context.cc
@@ -331,12 +331,21 @@ bool ContextBase::onStart(std::shared_ptr<PluginBase> plugin) {
 }
 
 bool ContextBase::onConfigure(std::shared_ptr<PluginBase> plugin) {
-  if (!in_vm_context_created_ && wasm_->on_context_create_) {
-    wasm_->on_context_create_(this, id_, 0);
-    in_vm_context_created_ = true;
+  if (isFailed()) {
+    return true;
   }
 
-  if (isFailed() || !wasm_->on_configure_) {
+  // on_context_create is yet to be executed for all the root contexts except the first one
+  if (!in_vm_context_created_ && wasm_->on_context_create_) {
+    DeferAfterCallActions actions(this);
+    wasm_->on_context_create_(this, id_, 0);
+  }
+
+  // NB: If no on_context_create function is registered the in-VM SDK is responsible for
+  // managing any required in-VM state.
+  in_vm_context_created_ = true;
+
+  if (!wasm_->on_configure_) {
     return true;
   }
 


### PR DESCRIPTION
Fix the bug in using a same`wasm` file for multiple times with a same VM ID:
- `on_context_create_` is invoked only for the first root context (this is because `on_context_create_` is executed in onStart)
-  `onConfigure` is executed for the other root contexts without invoking `on_context_create_`,

As far as I know, this results in panics in [Rust](https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/master/src/dispatcher.rs#L210) and [TinyGo](https://github.com/tetratelabs/proxy-wasm-go-sdk/blob/main/proxywasm/abi_configuration.go#L31) SDKs, and is not the intended behavior.
___

Signed-off-by: mathetake <takeshi@tetrate.io>