### PR TITLE
export wasi_clock_time_get

### DIFF
--- a/include/proxy-wasm/exports.h
+++ b/include/proxy-wasm/exports.h
@@ -144,7 +144,7 @@ Word wasi_unstable_environ_sizes_get(void *raw_context, Word count_ptr, Word buf
 Word wasi_unstable_args_get(void *raw_context, Word argc_ptr, Word argv_buf_size_ptr);
 Word wasi_unstable_args_sizes_get(void *raw_context, Word argc_ptr, Word argv_buf_size_ptr);
 void wasi_unstable_proc_exit(void *, Word);
-void wasi_unstable_proc_exit(void *, Word);
+Word wasi_unstable_clock_time_get(void *, Word, uint64_t, Word);
 Word pthread_equal(void *, Word left, Word right);
 
 // Support for embedders, not exported to Wasm.

--- a/include/proxy-wasm/wasm_vm.h
+++ b/include/proxy-wasm/wasm_vm.h
@@ -17,8 +17,8 @@
 
 #include <functional>
 #include <memory>
-#include <string>
 #include <optional>
+#include <string>
 
 #include "include/proxy-wasm/word.h"
 
@@ -78,6 +78,7 @@ template <size_t N> using WasmCallbackWord = WasmFuncType<N, Word, void *, Word>
 using WasmCallback_WWl = Word (*)(void *, Word, int64_t);
 using WasmCallback_WWlWW = Word (*)(void *, Word, int64_t, Word, Word);
 using WasmCallback_WWm = Word (*)(void *, Word, uint64_t);
+using WasmCallback_WWmW = Word (*)(void *, Word, uint64_t, Word);
 using WasmCallback_dd = double (*)(void *, double);
 
 #define FOR_ALL_WASM_VM_IMPORTS(_f)                                                                \
@@ -94,7 +95,8 @@ using WasmCallback_dd = double (*)(void *, double);
                                           _f(proxy_wasm::WasmCallback_WWl)                         \
                                               _f(proxy_wasm::WasmCallback_WWlWW)                   \
                                                   _f(proxy_wasm::WasmCallback_WWm)                 \
-                                                      _f(proxy_wasm::WasmCallback_dd)
+                                                      _f(proxy_wasm::WasmCallback_WWmW)            \
+                                                          _f(proxy_wasm::WasmCallback_dd)
 
 enum class Cloneable {
   NotCloneable,      // VMs can not be cloned and should be created from scratch.

--- a/src/exports.cc
+++ b/src/exports.cc
@@ -798,6 +798,22 @@ Word wasi_unstable_args_sizes_get(void *raw_context, Word argc_ptr, Word argv_bu
   return 0; // __WASI_ESUCCESS
 }
 
+// __wasi_errno_t __wasi_clock_time_get(uint32_t id, uint64_t precision, uint64_t* time);
+Word wasi_unstable_clock_time_get(void *raw_context, Word clock_id, uint64_t precision,
+                                  Word result_time_uint64_ptr) {
+
+  if (clock_id != 0 /* realtime */) {
+    return 58; // __WASI_ENOTSUP
+  }
+
+  auto context = WASM_CONTEXT(raw_context);
+  uint64_t result = context->getCurrentTimeNanoseconds();
+  if (!context->wasm()->setDatatype(result_time_uint64_ptr, result)) {
+    return 21; // __WASI_EFAULT
+  }
+  return 0; // __WASI_ESUCCESS
+}
+
 // void __wasi_proc_exit(__wasi_exitcode_t rval);
 void wasi_unstable_proc_exit(void *raw_context, Word) {
   auto context = WASM_CONTEXT(raw_context);

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -131,6 +131,7 @@ void WasmBase::registerCallbacks() {
   _REGISTER_WASI(environ_sizes_get);
   _REGISTER_WASI(args_get);
   _REGISTER_WASI(args_sizes_get);
+  _REGISTER_WASI(clock_time_get);
   _REGISTER_WASI(proc_exit);
 #undef _REGISTER_WASI
 


### PR DESCRIPTION
this PR implements WASI's `clock_time_get`. Some of languages assume that clock_time_get is available in the host for their runtime or their standard libraries. I think it's plausible to implement this now (I know in the next version of ABI `get_current_time_nanoseconds` is removed and we are encouraged to use this `clock_time_get`).

___

Signed-off-by: mathetake <takeshi@tetrate.io>