### PR TITLE
Fix getRootContext().

### DIFF
--- a/include/proxy-wasm/wasm.h
+++ b/include/proxy-wasm/wasm.h
@@ -59,9 +59,7 @@ public:
   std::string_view vm_key() const { return vm_key_; }
   WasmVm *wasm_vm() const { return wasm_vm_.get(); }
   ContextBase *vm_context() const { return vm_context_.get(); }
-  ContextBase *getRootContext(std::string_view root_id) {
-    return root_contexts_[std::string(root_id)].get();
-  }
+  ContextBase *getRootContext(std::string_view root_id);
   ContextBase *getOrCreateRootContext(const std::shared_ptr<PluginBase> &plugin);
   ContextBase *getContext(uint32_t id) {
     auto it = contexts_.find(id);

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -314,6 +314,14 @@ bool WasmBase::initialize(const std::string &code, bool allow_precompiled) {
   return !isFailed();
 }
 
+ContextBase *WasmBase::getRootContext(std::string_view root_id) {
+  auto it = root_contexts_.find(std::string(root_id));
+  if (it == root_contexts_.end()) {
+    return nullptr;
+  }
+  return it->second.get();
+}
+
 ContextBase *WasmBase::getOrCreateRootContext(const std::shared_ptr<PluginBase> &plugin) {
   auto root_context = getRootContext(plugin->root_id_);
   if (!root_context) {


### PR DESCRIPTION
Previously, getRootContext() was adding an empty entry to the map.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>