### PR TITLE
Use proxy_on_memory_allocate() as a fallback for malloc().

### DIFF
--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -193,14 +193,19 @@ void WasmBase::registerCallbacks() {
 
 void WasmBase::getFunctions() {
 #define _GET(_fn) wasm_vm_->getFunction(#_fn, &_fn##_);
+#define _GET_ALIAS(_fn, _alias) wasm_vm_->getFunction(#_alias, &_fn##_);
   _GET(_initialize);
   _GET(_start);
   _GET(__wasm_call_ctors);
 
   _GET(malloc);
   if (!malloc_) {
+    _GET_ALIAS(malloc, proxy_on_memory_allocate);
+  }
+  if (!malloc_) {
     fail(FailState::MissingFunction, "Wasm module is missing malloc function.");
   }
+#undef _GET_ALIAS
 #undef _GET
 
 #define _GET_PROXY(_fn) wasm_vm_->getFunction("proxy_" #_fn, &_fn##_);


### PR DESCRIPTION
On some targets (e.g. Rust's wasm32-wasi), it's impossible to export
malloc due to a collision with libc's malloc.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>