### PR TITLE
v8: enhance signature mimatch message in getModuleFunction

### DIFF
--- a/src/v8/v8.cc
+++ b/src/v8/v8.cc
@@ -586,11 +586,17 @@ void V8::getModuleFunctionImpl(std::string_view function_name,
     *function = nullptr;
     return;
   }
+
   const wasm::Func *func = it->second.get();
-  if (!equalValTypes(func->type()->params(), convertArgsTupleToValTypes<std::tuple<Args...>>()) ||
-      !equalValTypes(func->type()->results(), convertArgsTupleToValTypes<std::tuple<>>())) {
+  auto arg_valtypes = convertArgsTupleToValTypes<std::tuple<Args...>>();
+  auto result_valtypes = convertArgsTupleToValTypes<std::tuple<>>();
+  if (!equalValTypes(func->type()->params(), arg_valtypes) ||
+      !equalValTypes(func->type()->results(), result_valtypes)) {
     fail(FailState::UnableToInitializeCode,
-         std::string("Bad function signature for: ") + std::string(function_name));
+         "Bad function signature for: " + std::string(function_name) +
+             ", want: " + printValTypes(arg_valtypes) + " -> " + printValTypes(result_valtypes) +
+             ", but the module exports: " + printValTypes(func->type()->params()) + " -> " +
+             printValTypes(result_valtypes));
     *function = nullptr;
     return;
   }
@@ -614,10 +620,15 @@ void V8::getModuleFunctionImpl(std::string_view function_name,
     return;
   }
   const wasm::Func *func = it->second.get();
-  if (!equalValTypes(func->type()->params(), convertArgsTupleToValTypes<std::tuple<Args...>>()) ||
-      !equalValTypes(func->type()->results(), convertArgsTupleToValTypes<std::tuple<R>>())) {
+  auto arg_valtypes = convertArgsTupleToValTypes<std::tuple<Args...>>();
+  auto result_valtypes = convertArgsTupleToValTypes<std::tuple<R>>();
+  if (!equalValTypes(func->type()->params(), arg_valtypes) ||
+      !equalValTypes(func->type()->results(), result_valtypes)) {
     fail(FailState::UnableToInitializeCode,
-         "Bad function signature for: " + std::string(function_name));
+         "Bad function signature for: " + std::string(function_name) +
+             ", want: " + printValTypes(arg_valtypes) + " -> " + printValTypes(result_valtypes) +
+             ", but the module exports: " + printValTypes(func->type()->params()) + " -> " +
+             printValTypes(result_valtypes));
     *function = nullptr;
     return;
   }

--- a/src/v8/v8.cc
+++ b/src/v8/v8.cc
@@ -586,7 +586,6 @@ void V8::getModuleFunctionImpl(std::string_view function_name,
     *function = nullptr;
     return;
   }
-
   const wasm::Func *func = it->second.get();
   auto arg_valtypes = convertArgsTupleToValTypes<std::tuple<Args...>>();
   auto result_valtypes = convertArgsTupleToValTypes<std::tuple<>>();


### PR DESCRIPTION
Signed-off-by: mathetake <takeshi@tetrate.io>

resolves #74 

the following is an example message:
```
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 -> void, but the module exports: i32 i32 -> void
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 i32 -> void, but the module exports: i32 i32 -> void
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 -> i32, but the module exports: i32 i32 -> i32
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 i32 i32 -> i32, but the module exports: i32 i32 -> i32
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 i32 i32 -> i32, but the module exports: i32 i32 -> i32
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 i32 -> void, but the module exports: i32 i32 -> void
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 i32 -> void, but the module exports: i32 i32 -> void
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 i32 i32 -> i32, but the module exports: i32 i32 -> i32
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 i32 i32 -> i32, but the module exports: i32 i32 -> i32
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 i32 i32 i32 i32 -> void, but the module exports: i32 i32 -> void
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 i32 i32 -> void, but the module exports: i32 i32 -> void
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 i32 i32 -> void, but the module exports: i32 i32 -> void
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 i32 i32 -> void, but the module exports: i32 i32 -> void
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 i32 i32 -> void, but the module exports: i32 i32 -> void
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 i32 -> void, but the module exports: i32 i32 -> void
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 -> i32, but the module exports: i32 i32 -> i32
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 -> void, but the module exports: i32 i32 -> void
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 -> void, but the module exports: i32 i32 -> void
[source/extensions/common/wasm/wasm_vm.cc:29] Bad function signature for: proxy_on_vm_start, want: i32 i32 i32 -> void, but the module exports: i32 i32 -> void
```