### PR TITLE
wavm: emit stack trace when an exception happens

### DIFF
--- a/src/wavm/wavm.cc
+++ b/src/wavm/wavm.cc
@@ -17,10 +17,12 @@
 #include "include/proxy-wasm/wasm_vm.h"
 
 #include <cstdlib>
+#include <iomanip>
 #include <iostream>
 #include <map>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -108,12 +110,14 @@ std::string getFailMessage(std::string_view function_name, WAVM::Runtime::Except
   // Since the first frame is on host and useless for developers, e.g.: `host!envoy+112901013`
   // we start with index 1 here
   for (size_t i = 1; i < callstack_descriptions.size(); i++) {
+    std::ostringstream oss;
     std::string description = callstack_descriptions[i];
     if (description.find("wasm!") == std::string::npos) {
       // end of WASM's call stack
       break;
     }
-    message += "  " + std::to_string(i) + ": " + description + "\n";
+    oss << std::setw(3) << std::setfill(' ') << std::to_string(i);
+    message += oss.str() + ": " + description + "\n";
   }
 
   WAVM::Runtime::destroyException(exception);

--- a/src/wavm/wavm.cc
+++ b/src/wavm/wavm.cc
@@ -99,9 +99,9 @@ namespace {
   } while (0)
 
 std::string getFailMessage(std::string_view function_name, WAVM::Runtime::Exception *exception) {
-  std::string message = "Function " + std::string(function_name) + " failed:\n" +
-                        "WAVM message: " + WAVM::Runtime::describeExceptionType(exception->type) +
-                        "\nwasm backrace:\n";
+  std::string message = "Function " + std::string(function_name) +
+                        " failed: " + WAVM::Runtime::describeExceptionType(exception->type) +
+                        "\nProxy-Wasm plugin in-VM backtrace:\n";
   std::vector<std::string> callstack_descriptions =
       WAVM::Runtime::describeCallStack(exception->callStack);
 


### PR DESCRIPTION
this PR emits call stack trace when exception happens in WAVM just like V8 (#66)

this requires a change in the WAVM library used in Envoy: https://github.com/envoyproxy/envoy/pull/13792

```
[2020-10-28 14:24:10.551][979699][trace][wasm] [source/extensions/common/wasm/wasm_vm.cc:29] Function proxy_on_tick failed:
WAVM message: wavm.reachedUnreachable
wasm backrace:
  1: wasm!helloworld!runtime._panic+7
  2: wasm!helloworld!command-line-arguments.C+2
  3: wasm!helloworld!command-line-arguments.B+0
  4: wasm!helloworld!command-line-arguments.A+0
  5: wasm!helloworld!(*command-line-arguments.helloWorld).OnTick+74
  6: wasm!helloworld!proxy_on_tick+0
```

Signed-off-by: mathetake <takeshi@tetrate.io>