### PR TITLE
Clear stop_iteration_ in DeferAfterCallActions destructor

### DIFF
--- a/include/proxy-wasm/context.h
+++ b/include/proxy-wasm/context.h
@@ -377,6 +377,7 @@ public:
 
 protected:
   friend class WasmBase;
+  friend class DeferAfterCallActions;
 
   void initializeRootBase(WasmBase *wasm, std::shared_ptr<PluginBase> plugin);
   std::string makeRootLogPrefix(std::string_view vm_id) const;
@@ -402,11 +403,12 @@ private:
 
 class DeferAfterCallActions {
 public:
-  DeferAfterCallActions(ContextBase *context) : wasm_(context->wasm()) {}
+  DeferAfterCallActions(ContextBase *context) : context_(context) {}
   ~DeferAfterCallActions();
 
+protected:
 private:
-  WasmBase *const wasm_;
+  ContextBase *const context_;
 };
 
 uint32_t resolveQueueForTest(std::string_view vm_id, std::string_view queue_name);

--- a/include/proxy-wasm/context.h
+++ b/include/proxy-wasm/context.h
@@ -372,7 +372,6 @@ public:
 
 protected:
   friend class WasmBase;
-  friend class DeferAfterCallActions;
 
   void initializeRootBase(WasmBase *wasm, std::shared_ptr<PluginBase> plugin);
   std::string makeRootLogPrefix(std::string_view vm_id) const;
@@ -397,11 +396,11 @@ private:
 
 class DeferAfterCallActions {
 public:
-  DeferAfterCallActions(ContextBase *context) : context_(context) {}
+  DeferAfterCallActions(ContextBase *context) : wasm_(context->wasm()) {}
   ~DeferAfterCallActions();
 
 private:
-  ContextBase *const context_;
+  WasmBase *const wasm_;
 };
 
 uint32_t resolveQueueForTest(std::string_view vm_id, std::string_view queue_name);

--- a/include/proxy-wasm/context.h
+++ b/include/proxy-wasm/context.h
@@ -167,11 +167,6 @@ public:
   // Called before deleting the context.
   virtual void destroy();
 
-  // Called to raise the flag which indicates that the context should stop iteration regardless of
-  // returned filter status from Proxy-Wasm extensions. For example, we ignore
-  // FilterHeadersStatus::Continue after a local reponse is sent by the host.
-  void stopIteration() { stop_iteration_ = true; };
-
   /**
    * Calls into the VM.
    * These are implemented by the proxy-independent host code. They are virtual to support some
@@ -391,7 +386,6 @@ protected:
   std::shared_ptr<PluginBase> plugin_;
   bool in_vm_context_created_ = false;
   bool destroyed_ = false;
-  bool stop_iteration_ = false;
 
 private:
   // helper functions

--- a/include/proxy-wasm/context.h
+++ b/include/proxy-wasm/context.h
@@ -406,7 +406,6 @@ public:
   DeferAfterCallActions(ContextBase *context) : context_(context) {}
   ~DeferAfterCallActions();
 
-protected:
 private:
   ContextBase *const context_;
 };

--- a/include/proxy-wasm/wasm.h
+++ b/include/proxy-wasm/wasm.h
@@ -122,6 +122,12 @@ public:
 
   AbiVersion abiVersion() { return abi_version_; }
 
+  // Called to raise the flag which indicates that the context should stop iteration regardless of
+  // returned filter status from Proxy-Wasm extensions. For example, we ignore
+  // FilterHeadersStatus::Continue after a local reponse is sent by the host.
+  void stopNextIteration(bool stop) { stop_iteration_ = stop; };
+  bool isNextIterationStopped() { return stop_iteration_; };
+
   void addAfterVmCallAction(std::function<void()> f) { after_vm_call_actions_.push_back(f); }
   void doAfterVmCallActions() {
     // NB: this may be deleted by a delayed function unless prevented.
@@ -223,6 +229,7 @@ protected:
   std::string code_;
   std::string vm_configuration_;
   bool allow_precompiled_ = false;
+  bool stop_iteration_ = false;
   FailState failed_ = FailState::Ok; // Wasm VM fatal error.
 
   // ABI version.

--- a/src/context.cc
+++ b/src/context.cc
@@ -627,7 +627,6 @@ WasmResult ContextBase::setTimerPeriod(std::chrono::milliseconds period,
 FilterHeadersStatus ContextBase::convertVmCallResultToFilterHeadersStatus(uint64_t result) {
   if (stop_iteration_ ||
       result > static_cast<uint64_t>(FilterHeadersStatus::StopAllIterationAndWatermark)) {
-    stop_iteration_ = false;
     return FilterHeadersStatus::StopAllIterationAndWatermark;
   }
   return static_cast<FilterHeadersStatus>(result);
@@ -635,7 +634,6 @@ FilterHeadersStatus ContextBase::convertVmCallResultToFilterHeadersStatus(uint64
 
 FilterDataStatus ContextBase::convertVmCallResultToFilterDataStatus(uint64_t result) {
   if (stop_iteration_ || result > static_cast<uint64_t>(FilterDataStatus::StopIterationNoBuffer)) {
-    stop_iteration_ = false;
     return FilterDataStatus::StopIterationNoBuffer;
   }
   return static_cast<FilterDataStatus>(result);
@@ -643,7 +641,6 @@ FilterDataStatus ContextBase::convertVmCallResultToFilterDataStatus(uint64_t res
 
 FilterTrailersStatus ContextBase::convertVmCallResultToFilterTrailersStatus(uint64_t result) {
   if (stop_iteration_ || result > static_cast<uint64_t>(FilterTrailersStatus::StopIteration)) {
-    stop_iteration_ = false;
     return FilterTrailersStatus::StopIteration;
   }
   return static_cast<FilterTrailersStatus>(result);

--- a/src/context.cc
+++ b/src/context.cc
@@ -226,8 +226,8 @@ SharedData global_shared_data;
 } // namespace
 
 DeferAfterCallActions::~DeferAfterCallActions() {
-  context_->wasm()->stopNextIteration(false);
-  context_->wasm()->doAfterVmCallActions();
+  wasm_->stopNextIteration(false);
+  wasm_->doAfterVmCallActions();
 }
 
 WasmResult BufferBase::copyTo(WasmBase *wasm, size_t start, size_t length, uint64_t ptr_ptr,

--- a/src/context.cc
+++ b/src/context.cc
@@ -226,7 +226,7 @@ SharedData global_shared_data;
 } // namespace
 
 DeferAfterCallActions::~DeferAfterCallActions() {
-  context_->stop_iteration_ = false;
+  context_->wasm()->stopNextIteration(false);
   context_->wasm()->doAfterVmCallActions();
 }
 
@@ -625,7 +625,7 @@ WasmResult ContextBase::setTimerPeriod(std::chrono::milliseconds period,
 }
 
 FilterHeadersStatus ContextBase::convertVmCallResultToFilterHeadersStatus(uint64_t result) {
-  if (stop_iteration_ ||
+  if (wasm()->isNextIterationStopped() ||
       result > static_cast<uint64_t>(FilterHeadersStatus::StopAllIterationAndWatermark)) {
     return FilterHeadersStatus::StopAllIterationAndWatermark;
   }
@@ -633,14 +633,16 @@ FilterHeadersStatus ContextBase::convertVmCallResultToFilterHeadersStatus(uint64
 }
 
 FilterDataStatus ContextBase::convertVmCallResultToFilterDataStatus(uint64_t result) {
-  if (stop_iteration_ || result > static_cast<uint64_t>(FilterDataStatus::StopIterationNoBuffer)) {
+  if (wasm()->isNextIterationStopped() ||
+      result > static_cast<uint64_t>(FilterDataStatus::StopIterationNoBuffer)) {
     return FilterDataStatus::StopIterationNoBuffer;
   }
   return static_cast<FilterDataStatus>(result);
 }
 
 FilterTrailersStatus ContextBase::convertVmCallResultToFilterTrailersStatus(uint64_t result) {
-  if (stop_iteration_ || result > static_cast<uint64_t>(FilterTrailersStatus::StopIteration)) {
+  if (wasm()->isNextIterationStopped() ||
+      result > static_cast<uint64_t>(FilterTrailersStatus::StopIteration)) {
     return FilterTrailersStatus::StopIteration;
   }
   return static_cast<FilterTrailersStatus>(result);

--- a/src/context.cc
+++ b/src/context.cc
@@ -225,7 +225,10 @@ SharedData global_shared_data;
 
 } // namespace
 
-DeferAfterCallActions::~DeferAfterCallActions() { wasm_->doAfterVmCallActions(); }
+DeferAfterCallActions::~DeferAfterCallActions() {
+  context_->stop_iteration_ = false;
+  context_->wasm()->doAfterVmCallActions();
+}
 
 WasmResult BufferBase::copyTo(WasmBase *wasm, size_t start, size_t length, uint64_t ptr_ptr,
                               uint64_t size_ptr) const {

--- a/src/exports.cc
+++ b/src/exports.cc
@@ -186,7 +186,7 @@ Word send_local_response(void *raw_context, Word response_code, Word response_co
   auto additional_headers = toPairs(additional_response_header_pairs.value());
   context->sendLocalResponse(response_code, body.value(), std::move(additional_headers), grpc_code,
                              details.value());
-  context->stopIteration();
+  context->wasm()->stopNextIteration(true);
   return WasmResult::Ok;
 }
 


### PR DESCRIPTION
Signed-off-by: mathetake <takeshi@tetrate.io>

ref: https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/88#issuecomment-724436498