### PR TITLE
Optionally call main() in WASI reactors as a convenience.

### DIFF
--- a/include/proxy-wasm/wasm.h
+++ b/include/proxy-wasm/wasm.h
@@ -196,10 +196,10 @@ protected:
   std::unordered_map<std::string, std::string>
       envs_; // environment variables passed through wasi.environ_get
 
-  WasmCallVoid<0> _initialize_; /* Emscripten v1.39.17+ */
-  WasmCallVoid<0> _start_;      /* Emscripten v1.39.0+ */
-  WasmCallVoid<0> __wasm_call_ctors_;
+  WasmCallVoid<0> _initialize_; /* WASI reactor (Emscripten v1.39.17+, Rust nightly) */
+  WasmCallVoid<0> _start_;      /* WASI command (Emscripten v1.39.0+, TinyGo) */
 
+  WasmCallWord<2> main_;
   WasmCallWord<1> malloc_;
 
   // Calls into the VM.

--- a/src/null/null_plugin.cc
+++ b/src/null/null_plugin.cc
@@ -37,8 +37,6 @@ void NullPlugin::getFunction(std::string_view function_name, WasmCallVoid<0> *f)
     *f = nullptr;
   } else if (function_name == "_start") {
     *f = nullptr;
-  } else if (function_name == "__wasm_call_ctors") {
-    *f = nullptr;
   } else if (!wasm_vm_->integration()->getNullVmFunction(function_name, false, 0, this, f)) {
     error("Missing getFunction for: " + std::string(function_name));
     *f = nullptr;
@@ -167,7 +165,9 @@ void NullPlugin::getFunction(std::string_view function_name, WasmCallWord<1> *f)
 
 void NullPlugin::getFunction(std::string_view function_name, WasmCallWord<2> *f) {
   auto plugin = this;
-  if (function_name == "proxy_on_vm_start") {
+  if (function_name == "main") {
+    *f = nullptr;
+  } else if (function_name == "proxy_on_vm_start") {
     *f = [plugin](ContextBase *context, Word context_id, Word configuration_size) {
       SaveRestoreContext saved_context(context);
       return Word(plugin->onStart(context_id, configuration_size));

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -147,8 +147,11 @@ void WasmBase::getFunctions() {
 #define _GET(_fn) wasm_vm_->getFunction(#_fn, &_fn##_);
 #define _GET_ALIAS(_fn, _alias) wasm_vm_->getFunction(#_alias, &_fn##_);
   _GET(_initialize);
-  _GET(_start);
-  _GET(__wasm_call_ctors);
+  if (_initialize_) {
+    _GET(main);
+  } else {
+    _GET(_start);
+  }
 
   _GET(malloc);
   if (!malloc_) {
@@ -284,11 +287,19 @@ ContextBase *WasmBase::getRootContext(const std::shared_ptr<PluginBase> &plugin,
 
 void WasmBase::startVm(ContextBase *root_context) {
   if (_initialize_) {
+    // WASI reactor.
     _initialize_(root_context);
+    if (main_) {
+      // Call main() if it exists in WASI reactor, to allow module to
+      // do early initialization (e.g. configure SDK).
+      //
+      // Re-using main() keeps this consistent when switching between
+      // WASI command (that calls main()) and reactor (that doesn't).
+      main_(root_context, Word(0), Word(0));
+    }
   } else if (_start_) {
+    // WASI command.
     _start_(root_context);
-  } else if (__wasm_call_ctors_) {
-    __wasm_call_ctors_(root_context);
   }
 }
 


### PR DESCRIPTION
WASI reactors differ from WASI commands in that they have multiple
entrypoints (i.e. proxy_on_* callbacks) instead of only main().

Currently, each Proxy-Wasm SDK uses different approch to startup:

- AssemblyScript SDK uses Wasm's start function.

- C++ SDK creates WASI reactor with global C++ constructors taking
  care of early initialization and registration of plugins.

- Rust SDK creates Wasm library, and suggests (via examples) using
  _start() function called at startup to do early initialization.
  Unfortunately, this is the same function name that WASI commands
  are using, which means that WASI constructors cannot be injected
  and executed at startup.

- TinyGo SDK creates WASI command and calls main() at startup, but
  it doesn't exit after main() function returns.

Calling main() in WASI reactors would allow us to prepare for when
they are stablized in Rust, and to have a non-breaking fallback in
case TinyGo decides to exit after main() function returns.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>