### PR TITLE
Fix environ_get: append null.

### DIFF
--- a/src/exports.cc
+++ b/src/exports.cc
@@ -781,7 +781,7 @@ Word wasi_unstable_environ_get(void *raw_context, Word environ_array_ptr, Word e
     data.append(e.first);
     data.append("=");
     data.append(e.second);
-    data.append("\x0");
+    data.append({0x0});
     if (!context->wasmVm()->setMemory(environ_buf, data.size(), data.c_str())) {
       return 21; // __WASI_EFAULT
     }

--- a/test/exports_test.cc
+++ b/test/exports_test.cc
@@ -67,8 +67,8 @@ TEST_P(TestVM, Environment) {
   run(current_context_);
 
   auto msg = context.log_msg();
-  EXPECT_NE(std::string::npos, msg.find("KEY1: VALUE1")) << msg;
-  EXPECT_NE(std::string::npos, msg.find("KEY2: VALUE2")) << msg;
+  EXPECT_NE(std::string::npos, msg.find("KEY1: VALUE1\n")) << msg;
+  EXPECT_NE(std::string::npos, msg.find("KEY2: VALUE2\n")) << msg;
 }
 
 TEST_P(TestVM, WithoutEnvironment) {

--- a/test/test_data/env.rs
+++ b/test/test_data/env.rs
@@ -23,6 +23,6 @@ pub extern "C" fn run() {
         __wasilibc_initialize_environ();
     }
     for (key, value) in std::env::vars() {
-        println!("{}: {}", key, value);
+        println!("{}: {}\n", key, value);
     }
 }


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>

found this bug while writing tests in Envoy: it looks like `append("\x0")` or `append("\0")` does nothing, and that would result in non-terminated values in the first env vars

```
KEY1: VALUE1KEY2=VALUE2
KEY2: VALUE2
```