### PR TITLE
v8: use signal handlers to catch out of bounds memory access.

### DIFF
--- a/src/v8/v8.cc
+++ b/src/v8/v8.cc
@@ -24,6 +24,7 @@
 #include <utility>
 #include <vector>
 
+#include "v8.h"
 #include "v8-version.h"
 #include "wasm-api/wasm.hh"
 
@@ -31,7 +32,11 @@ namespace proxy_wasm {
 namespace {
 
 wasm::Engine *engine() {
-  static const auto engine = wasm::Engine::make();
+  static wasm::own<wasm::Engine> engine;
+  if (engine.get() == nullptr) {
+    v8::V8::EnableWebAssemblyTrapHandler(true);
+    engine = wasm::Engine::make();
+  }
   return engine.get();
 }
 

--- a/src/v8/v8.cc
+++ b/src/v8/v8.cc
@@ -32,11 +32,14 @@ namespace proxy_wasm {
 namespace {
 
 wasm::Engine *engine() {
+  static std::once_flag init;
   static wasm::own<wasm::Engine> engine;
-  if (engine.get() == nullptr) {
+
+  std::call_once(init, []() {
     v8::V8::EnableWebAssemblyTrapHandler(true);
     engine = wasm::Engine::make();
-  }
+  });
+
   return engine.get();
 }
 

--- a/src/v8/v8.cc
+++ b/src/v8/v8.cc
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <iomanip>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <sstream>
 #include <unordered_map>


### PR DESCRIPTION
This change improves performance by up to 36% in microbenchmarks.

Benchmark                                                       Diff
--------------------------------------------------------------------
WasmSpeedTest_empty                                          -0.0185
WasmSpeedTest_get_current_time                               -0.1184
WasmSpeedTest_small_string                                   -0.0081
WasmSpeedTest_small_string1000                               -0.1324
WasmSpeedTest_small_string_check_compiler                    -0.0654
WasmSpeedTest_small_string_check_compiler1000                -0.1338
WasmSpeedTest_large_string                                   -0.3187
WasmSpeedTest_large_string1000                               -0.3624
WasmSpeedTest_get_property                                   -0.0213
WasmSpeedTest_grpc_service                                   -0.1426
WasmSpeedTest_grpc_service1000                               -0.2431
WasmSpeedTest_modify_metadata                                -0.0287
WasmSpeedTest_modify_metadata1000                            -0.0431
WasmSpeedTest_json_serialize                                 -0.2729
WasmSpeedTest_json_deserialize                               -0.2594
WasmSpeedTest_json_deserialize_empty                         -0.2609
WasmSpeedTest_convert_to_filter_state                        -0.2889

Signed-off-by: Piotr Sikora <piotrsikora@google.com>