### PR TITLE
Allow access to status message from a child context.

### DIFF
--- a/src/exports.cc
+++ b/src/exports.cc
@@ -130,7 +130,7 @@ Word get_configuration(void *raw_context, Word value_ptr_ptr, Word value_size_pt
 }
 
 Word get_status(void *raw_context, Word code_ptr, Word value_ptr_ptr, Word value_size_ptr) {
-  auto context = WASM_CONTEXT(raw_context);
+  auto context = WASM_CONTEXT(raw_context)->root_context();
   auto status = context->getStatus();
   if (!context->wasm()->setDatatype(code_ptr, status.first)) {
     return WasmResult::InvalidMemoryAccess;


### PR DESCRIPTION
Previously, proxy_get_status() would return status message only when it was
called from the root context, which doesn't work when the effective context
is automatically changed to the calling context as part of the SDK.

With this change, status can be accessed from either root or child context.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>