### PR TITLE
Pass plugin key from embedders to PluginBase.

### DIFF
--- a/include/proxy-wasm/context.h
+++ b/include/proxy-wasm/context.h
@@ -45,14 +45,16 @@ class WasmVm;
  * @param vm_id is a string used to differentiate VMs with the same code and VM configuration.
  * @param plugin_configuration is configuration for this plugin.
  * @param fail_open if true the plugin will pass traffic as opposed to close all streams.
+ * @param key is used for caching PluginHandleBase per thread and determining whether to create a
+ * new PluginHandleBase.
  */
 struct PluginBase {
   PluginBase(std::string_view name, std::string_view root_id, std::string_view vm_id,
-             std::string_view runtime, std::string_view plugin_configuration, bool fail_open)
+             std::string_view runtime, std::string_view plugin_configuration, bool fail_open,
+             std::string_view key)
       : name_(std::string(name)), root_id_(std::string(root_id)), vm_id_(std::string(vm_id)),
         runtime_(std::string(runtime)), plugin_configuration_(plugin_configuration),
-        fail_open_(fail_open), key_(root_id_ + "||" + plugin_configuration_),
-        log_prefix_(makeLogPrefix()) {}
+        fail_open_(fail_open), key_(key), log_prefix_(makeLogPrefix()) {}
 
   const std::string name_;
   const std::string root_id_;

--- a/include/proxy-wasm/context.h
+++ b/include/proxy-wasm/context.h
@@ -53,7 +53,8 @@ struct PluginBase {
              std::string_view key)
       : name_(std::string(name)), root_id_(std::string(root_id)), vm_id_(std::string(vm_id)),
         runtime_(std::string(runtime)), plugin_configuration_(plugin_configuration),
-        fail_open_(fail_open), key_(root_id_ + "||" + plugin_configuration_ + "||" + key),
+        fail_open_(fail_open),
+        key_(root_id_ + "||" + plugin_configuration_ + "||" + std::string(key)),
         log_prefix_(makeLogPrefix()) {}
 
   const std::string name_;

--- a/include/proxy-wasm/context.h
+++ b/include/proxy-wasm/context.h
@@ -45,8 +45,7 @@ class WasmVm;
  * @param vm_id is a string used to differentiate VMs with the same code and VM configuration.
  * @param plugin_configuration is configuration for this plugin.
  * @param fail_open if true the plugin will pass traffic as opposed to close all streams.
- * @param key is used for caching PluginHandleBase per thread and determining whether to create a
- * new PluginHandleBase.
+ * @param key is used to uniquely identify this plugin instance.
  */
 struct PluginBase {
   PluginBase(std::string_view name, std::string_view root_id, std::string_view vm_id,
@@ -54,7 +53,8 @@ struct PluginBase {
              std::string_view key)
       : name_(std::string(name)), root_id_(std::string(root_id)), vm_id_(std::string(vm_id)),
         runtime_(std::string(runtime)), plugin_configuration_(plugin_configuration),
-        fail_open_(fail_open), key_(key), log_prefix_(makeLogPrefix()) {}
+        fail_open_(fail_open), key_(root_id_ + "||" + plugin_configuration_ + "||" + key),
+        log_prefix_(makeLogPrefix()) {}
 
   const std::string name_;
   const std::string root_id_;


### PR DESCRIPTION
This PR allows embedders to pass plugin_key for PluginBases in order for it to include host specific information (e.g. listener info in Envoy).

ref https://github.com/envoyproxy/envoy/pull/17243#issuecomment-876811383

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>