### PR TITLE
test: remove no_mangle from extern "c"

### DIFF
--- a/test/test_data/env.rs
+++ b/test/test_data/env.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[no_mangle]
 extern "C" {
     fn __wasilibc_initialize_environ();
 }


### PR DESCRIPTION
This PR suppresses the warning by rustc: 

```
warning: attribute should be applied to a function or static
  --> test/test_data/env.rs:15:1
   |
15 |   #[no_mangle]
   |   ^^^^^^^^^^^^
16 | / extern "C" {
17 | |     fn __wasilibc_initialize_environ();
18 | | }
   | |_- not a function or static
   |
   = note: `#[warn(unused_attributes)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

warning: 1 warning emitted
```

extern "c" already guarantee that the symbol remains un-mangled, so it is safe to remove it. Will make the same change to ~rust-sdk and~ Envoy tests.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>