### PR TITLE
Delete unused raw_context arg in host functions.

### DIFF
--- a/include/proxy-wasm/exports.h
+++ b/include/proxy-wasm/exports.h
@@ -25,6 +25,9 @@ namespace proxy_wasm {
 
 class ContextBase;
 
+// Any currently executing Wasm call context.
+::proxy_wasm::ContextBase *contextOrEffectiveContext();
+
 extern thread_local ContextBase *current_context_;
 
 namespace exports {
@@ -61,99 +64,86 @@ template <typename Pairs> void marshalPairs(const Pairs &result, char *buffer) {
 
 // ABI functions exported from host to wasm.
 
-Word get_configuration(void *raw_context, Word address, Word size);
-Word get_status(void *raw_context, Word status_code, Word address, Word size);
-Word log(void *raw_context, Word level, Word address, Word size);
-Word get_log_level(void *raw_context, Word result_level_uint32_ptr);
-Word get_property(void *raw_context, Word path_ptr, Word path_size, Word value_ptr_ptr,
-                  Word value_size_ptr);
-Word set_property(void *raw_context, Word key_ptr, Word key_size, Word value_ptr, Word value_size);
-Word continue_request(void *raw_context);
-Word continue_response(void *raw_context);
-Word continue_stream(void *raw_context, Word stream_type);
-Word close_stream(void *raw_context, Word stream_type);
-Word send_local_response(void *raw_context, Word response_code, Word response_code_details_ptr,
+Word get_configuration(Word address, Word size);
+Word get_status(Word status_code, Word address, Word size);
+Word log(Word level, Word address, Word size);
+Word get_log_level(Word result_level_uint32_ptr);
+Word get_property(Word path_ptr, Word path_size, Word value_ptr_ptr, Word value_size_ptr);
+Word set_property(Word key_ptr, Word key_size, Word value_ptr, Word value_size);
+Word continue_request();
+Word continue_response();
+Word continue_stream(Word stream_type);
+Word close_stream(Word stream_type);
+Word send_local_response(Word response_code, Word response_code_details_ptr,
                          Word response_code_details_size, Word body_ptr, Word body_size,
                          Word additional_response_header_pairs_ptr,
                          Word additional_response_header_pairs_size, Word grpc_status);
-Word clear_route_cache(void *raw_context);
-Word get_shared_data(void *raw_context, Word key_ptr, Word key_size, Word value_ptr_ptr,
-                     Word value_size_ptr, Word cas_ptr);
-Word set_shared_data(void *raw_context, Word key_ptr, Word key_size, Word value_ptr,
-                     Word value_size, Word cas);
-Word register_shared_queue(void *raw_context, Word queue_name_ptr, Word queue_name_size,
-                           Word token_ptr);
-Word resolve_shared_queue(void *raw_context, Word vm_id_ptr, Word vm_id_size, Word queue_name_ptr,
+Word clear_route_cache();
+Word get_shared_data(Word key_ptr, Word key_size, Word value_ptr_ptr, Word value_size_ptr,
+                     Word cas_ptr);
+Word set_shared_data(Word key_ptr, Word key_size, Word value_ptr, Word value_size, Word cas);
+Word register_shared_queue(Word queue_name_ptr, Word queue_name_size, Word token_ptr);
+Word resolve_shared_queue(Word vm_id_ptr, Word vm_id_size, Word queue_name_ptr,
                           Word queue_name_size, Word token_ptr);
-Word dequeue_shared_queue(void *raw_context, Word token, Word data_ptr_ptr, Word data_size_ptr);
-Word enqueue_shared_queue(void *raw_context, Word token, Word data_ptr, Word data_size);
-Word get_buffer_bytes(void *raw_context, Word type, Word start, Word length, Word ptr_ptr,
-                      Word size_ptr);
-Word get_buffer_status(void *raw_context, Word type, Word length_ptr, Word flags_ptr);
-Word set_buffer_bytes(void *raw_context, Word type, Word start, Word length, Word data_ptr,
-                      Word data_size);
-Word add_header_map_value(void *raw_context, Word type, Word key_ptr, Word key_size, Word value_ptr,
-                          Word value_size);
-Word get_header_map_value(void *raw_context, Word type, Word key_ptr, Word key_size,
-                          Word value_ptr_ptr, Word value_size_ptr);
-Word replace_header_map_value(void *raw_context, Word type, Word key_ptr, Word key_size,
-                              Word value_ptr, Word value_size);
-Word remove_header_map_value(void *raw_context, Word type, Word key_ptr, Word key_size);
-Word get_header_map_pairs(void *raw_context, Word type, Word ptr_ptr, Word size_ptr);
-Word set_header_map_pairs(void *raw_context, Word type, Word ptr, Word size);
-Word get_header_map_size(void *raw_context, Word type, Word result_ptr);
-Word getRequestBodyBufferBytes(void *raw_context, Word start, Word length, Word ptr_ptr,
-                               Word size_ptr);
-Word get_response_body_buffer_bytes(void *raw_context, Word start, Word length, Word ptr_ptr,
-                                    Word size_ptr);
-Word http_call(void *raw_context, Word uri_ptr, Word uri_size, Word header_pairs_ptr,
-               Word header_pairs_size, Word body_ptr, Word body_size, Word trailer_pairs_ptr,
-               Word trailer_pairs_size, Word timeout_milliseconds, Word token_ptr);
-Word define_metric(void *raw_context, Word metric_type, Word name_ptr, Word name_size,
-                   Word result_ptr);
-Word increment_metric(void *raw_context, Word metric_id, int64_t offset);
-Word record_metric(void *raw_context, Word metric_id, uint64_t value);
-Word get_metric(void *raw_context, Word metric_id, Word result_uint64_ptr);
-Word grpc_call(void *raw_context, Word service_ptr, Word service_size, Word service_name_ptr,
-               Word service_name_size, Word method_name_ptr, Word method_name_size,
-               Word initial_metadata_ptr, Word initial_metadata_size, Word request_ptr,
-               Word request_size, Word timeout_milliseconds, Word token_ptr);
-Word grpc_stream(void *raw_context, Word service_ptr, Word service_size, Word service_name_ptr,
-                 Word service_name_size, Word method_name_ptr, Word method_name_size,
-                 Word initial_metadata_ptr, Word initial_metadata_size, Word token_ptr);
-Word grpc_cancel(void *raw_context, Word token);
-Word grpc_close(void *raw_context, Word token);
-Word grpc_send(void *raw_context, Word token, Word message_ptr, Word message_size, Word end_stream);
+Word dequeue_shared_queue(Word token, Word data_ptr_ptr, Word data_size_ptr);
+Word enqueue_shared_queue(Word token, Word data_ptr, Word data_size);
+Word get_buffer_bytes(Word type, Word start, Word length, Word ptr_ptr, Word size_ptr);
+Word get_buffer_status(Word type, Word length_ptr, Word flags_ptr);
+Word set_buffer_bytes(Word type, Word start, Word length, Word data_ptr, Word data_size);
+Word add_header_map_value(Word type, Word key_ptr, Word key_size, Word value_ptr, Word value_size);
+Word get_header_map_value(Word type, Word key_ptr, Word key_size, Word value_ptr_ptr,
+                          Word value_size_ptr);
+Word replace_header_map_value(Word type, Word key_ptr, Word key_size, Word value_ptr,
+                              Word value_size);
+Word remove_header_map_value(Word type, Word key_ptr, Word key_size);
+Word get_header_map_pairs(Word type, Word ptr_ptr, Word size_ptr);
+Word set_header_map_pairs(Word type, Word ptr, Word size);
+Word get_header_map_size(Word type, Word result_ptr);
+Word getRequestBodyBufferBytes(Word start, Word length, Word ptr_ptr, Word size_ptr);
+Word get_response_body_buffer_bytes(Word start, Word length, Word ptr_ptr, Word size_ptr);
+Word http_call(Word uri_ptr, Word uri_size, Word header_pairs_ptr, Word header_pairs_size,
+               Word body_ptr, Word body_size, Word trailer_pairs_ptr, Word trailer_pairs_size,
+               Word timeout_milliseconds, Word token_ptr);
+Word define_metric(Word metric_type, Word name_ptr, Word name_size, Word result_ptr);
+Word increment_metric(Word metric_id, int64_t offset);
+Word record_metric(Word metric_id, uint64_t value);
+Word get_metric(Word metric_id, Word result_uint64_ptr);
+Word grpc_call(Word service_ptr, Word service_size, Word service_name_ptr, Word service_name_size,
+               Word method_name_ptr, Word method_name_size, Word initial_metadata_ptr,
+               Word initial_metadata_size, Word request_ptr, Word request_size,
+               Word timeout_milliseconds, Word token_ptr);
+Word grpc_stream(Word service_ptr, Word service_size, Word service_name_ptr, Word service_name_size,
+                 Word method_name_ptr, Word method_name_size, Word initial_metadata_ptr,
+                 Word initial_metadata_size, Word token_ptr);
+Word grpc_cancel(Word token);
+Word grpc_close(Word token);
+Word grpc_send(Word token, Word message_ptr, Word message_size, Word end_stream);
 
-Word set_tick_period_milliseconds(void *raw_context, Word tick_period_milliseconds);
-Word get_current_time_nanoseconds(void *raw_context, Word result_uint64_ptr);
+Word set_tick_period_milliseconds(Word tick_period_milliseconds);
+Word get_current_time_nanoseconds(Word result_uint64_ptr);
 
-Word set_effective_context(void *raw_context, Word context_id);
-Word done(void *raw_context);
-Word call_foreign_function(void *raw_context, Word function_name, Word function_name_size,
-                           Word arguments, Word warguments_size, Word results, Word results_size);
+Word set_effective_context(Word context_id);
+Word done();
+Word call_foreign_function(Word function_name, Word function_name_size, Word arguments,
+                           Word warguments_size, Word results, Word results_size);
 
 // Runtime environment functions exported from envoy to wasm.
 
-Word wasi_unstable_fd_write(void *raw_context, Word fd, Word iovs, Word iovs_len,
-                            Word nwritten_ptr);
-Word wasi_unstable_fd_read(void *, Word, Word, Word, Word);
-Word wasi_unstable_fd_seek(void *, Word, int64_t, Word, Word);
-Word wasi_unstable_fd_close(void *, Word);
-Word wasi_unstable_fd_fdstat_get(void *, Word fd, Word statOut);
-Word wasi_unstable_environ_get(void *, Word, Word);
-Word wasi_unstable_environ_sizes_get(void *raw_context, Word count_ptr, Word buf_size_ptr);
-Word wasi_unstable_args_get(void *raw_context, Word argc_ptr, Word argv_buf_size_ptr);
-Word wasi_unstable_args_sizes_get(void *raw_context, Word argc_ptr, Word argv_buf_size_ptr);
-void wasi_unstable_proc_exit(void *, Word);
-Word wasi_unstable_clock_time_get(void *, Word, uint64_t, Word);
-Word wasi_unstable_random_get(void *, Word, Word);
-Word pthread_equal(void *, Word left, Word right);
+Word wasi_unstable_fd_write(Word fd, Word iovs, Word iovs_len, Word nwritten_ptr);
+Word wasi_unstable_fd_read(Word, Word, Word, Word);
+Word wasi_unstable_fd_seek(Word, int64_t, Word, Word);
+Word wasi_unstable_fd_close(Word);
+Word wasi_unstable_fd_fdstat_get(Word fd, Word statOut);
+Word wasi_unstable_environ_get(Word, Word);
+Word wasi_unstable_environ_sizes_get(Word count_ptr, Word buf_size_ptr);
+Word wasi_unstable_args_get(Word argc_ptr, Word argv_buf_size_ptr);
+Word wasi_unstable_args_sizes_get(Word argc_ptr, Word argv_buf_size_ptr);
+void wasi_unstable_proc_exit(Word);
+Word wasi_unstable_clock_time_get(Word, uint64_t, Word);
+Word wasi_unstable_random_get(Word, Word);
+Word pthread_equal(Word left, Word right);
 
 // Support for embedders, not exported to Wasm.
-
-// Any currently executing Wasm call context.
-::proxy_wasm::ContextBase *ContextOrEffectiveContext(::proxy_wasm::ContextBase *context);
 
 #define FOR_ALL_HOST_FUNCTIONS(_f)                                                                 \
   _f(log) _f(get_status) _f(set_property) _f(get_property) _f(send_local_response)                 \
@@ -181,10 +171,9 @@ Word pthread_equal(void *, Word left, Word right);
 // Helpers to generate a stub to pass to VM, in place of a restricted proxy-wasm capability.
 #define _CREATE_PROXY_WASM_STUB(_fn)                                                               \
   template <typename F> struct _fn##Stub;                                                          \
-  template <typename... Args> struct _fn##Stub<Word(void *, Args...)> {                            \
-    static Word stub(void *raw_context, Args...) {                                                 \
-      auto context = exports::ContextOrEffectiveContext(                                           \
-          static_cast<ContextBase *>((void)raw_context, current_context_));                        \
+  template <typename... Args> struct _fn##Stub<Word(Args...)> {                                    \
+    static Word stub(Args...) {                                                                    \
+      auto context = contextOrEffectiveContext();                                                  \
       context->wasmVm()->integration()->error(                                                     \
           "Attempted call to restricted proxy-wasm capability: proxy_" #_fn);                      \
       return WasmResult::InternalFailure;                                                          \
@@ -197,19 +186,17 @@ FOR_ALL_HOST_FUNCTIONS_ABI_SPECIFIC(_CREATE_PROXY_WASM_STUB)
 // Helpers to generate a stub to pass to VM, in place of a restricted WASI capability.
 #define _CREATE_WASI_STUB(_fn)                                                                     \
   template <typename F> struct _fn##Stub;                                                          \
-  template <typename... Args> struct _fn##Stub<Word(void *, Args...)> {                            \
-    static Word stub(void *raw_context, Args...) {                                                 \
-      auto context = exports::ContextOrEffectiveContext(                                           \
-          static_cast<ContextBase *>((void)raw_context, current_context_));                        \
+  template <typename... Args> struct _fn##Stub<Word(Args...)> {                                    \
+    static Word stub(Args...) {                                                                    \
+      auto context = contextOrEffectiveContext();                                                  \
       context->wasmVm()->integration()->error(                                                     \
           "Attempted call to restricted WASI capability: " #_fn);                                  \
       return 76; /* __WASI_ENOTCAPABLE */                                                          \
     }                                                                                              \
   };                                                                                               \
-  template <typename... Args> struct _fn##Stub<void(void *, Args...)> {                            \
-    static void stub(void *raw_context, Args...) {                                                 \
-      auto context = exports::ContextOrEffectiveContext(                                           \
-          static_cast<ContextBase *>((void)raw_context, current_context_));                        \
+  template <typename... Args> struct _fn##Stub<void(Args...)> {                                    \
+    static void stub(Args...) {                                                                    \
+      auto context = contextOrEffectiveContext();                                                  \
       context->wasmVm()->integration()->error(                                                     \
           "Attempted call to restricted WASI capability: " #_fn);                                  \
     }                                                                                              \

--- a/include/proxy-wasm/wasm_api_impl.h
+++ b/include/proxy-wasm/wasm_api_impl.h
@@ -48,55 +48,51 @@ inline WasmResult wordToWasmResult(Word w) { return static_cast<WasmResult>(w.u6
 inline WasmResult proxy_get_configuration(const char **configuration_ptr,
                                           size_t *configuration_size) {
   return wordToWasmResult(
-      exports::get_configuration(current_context_, WR(configuration_ptr), WR(configuration_size)));
+      exports::get_configuration(WR(configuration_ptr), WR(configuration_size)));
 }
 
 inline WasmResult proxy_get_status(uint32_t *code_ptr, const char **ptr, size_t *size) {
-  return wordToWasmResult(exports::get_status(current_context_, WR(code_ptr), WR(ptr), WR(size)));
+  return wordToWasmResult(exports::get_status(WR(code_ptr), WR(ptr), WR(size)));
 }
 
 // Logging
 inline WasmResult proxy_log(LogLevel level, const char *logMessage, size_t messageSize) {
-  return wordToWasmResult(
-      exports::log(current_context_, WS(level), WR(logMessage), WS(messageSize)));
+  return wordToWasmResult(exports::log(WS(level), WR(logMessage), WS(messageSize)));
 }
 inline WasmResult proxy_get_log_level(LogLevel *level) {
-  return wordToWasmResult(exports::get_log_level(current_context_, WR(level)));
+  return wordToWasmResult(exports::get_log_level(WR(level)));
 }
 
 // Timer
 inline WasmResult proxy_set_tick_period_milliseconds(uint64_t millisecond) {
-  return wordToWasmResult(
-      exports::set_tick_period_milliseconds(current_context_, Word(millisecond)));
+  return wordToWasmResult(exports::set_tick_period_milliseconds(Word(millisecond)));
 }
 inline WasmResult proxy_get_current_time_nanoseconds(uint64_t *result) {
-  return wordToWasmResult(exports::get_current_time_nanoseconds(current_context_, WR(result)));
+  return wordToWasmResult(exports::get_current_time_nanoseconds(WR(result)));
 }
 
 // State accessors
 inline WasmResult proxy_get_property(const char *path_ptr, size_t path_size,
                                      const char **value_ptr_ptr, size_t *value_size_ptr) {
-  return wordToWasmResult(exports::get_property(current_context_, WR(path_ptr), WS(path_size),
-                                                WR(value_ptr_ptr), WR(value_size_ptr)));
+  return wordToWasmResult(
+      exports::get_property(WR(path_ptr), WS(path_size), WR(value_ptr_ptr), WR(value_size_ptr)));
 }
 inline WasmResult proxy_set_property(const char *key_ptr, size_t key_size, const char *value_ptr,
                                      size_t value_size) {
-  return wordToWasmResult(exports::set_property(current_context_, WR(key_ptr), WS(key_size),
-                                                WR(value_ptr), WS(value_size)));
+  return wordToWasmResult(
+      exports::set_property(WR(key_ptr), WS(key_size), WR(value_ptr), WS(value_size)));
 }
 
 // Continue
-inline WasmResult proxy_continue_request() {
-  return wordToWasmResult(exports::continue_request(current_context_));
-}
+inline WasmResult proxy_continue_request() { return wordToWasmResult(exports::continue_request()); }
 inline WasmResult proxy_continue_response() {
-  return wordToWasmResult(exports::continue_response(current_context_));
+  return wordToWasmResult(exports::continue_response());
 }
 inline WasmResult proxy_continue_stream(WasmStreamType stream_type) {
-  return wordToWasmResult(exports::continue_stream(current_context_, WS(stream_type)));
+  return wordToWasmResult(exports::continue_stream(WS(stream_type)));
 }
 inline WasmResult proxy_close_stream(WasmStreamType stream_type) {
-  return wordToWasmResult(exports::close_stream(current_context_, WS(stream_type)));
+  return wordToWasmResult(exports::close_stream(WS(stream_type)));
 }
 inline WasmResult
 proxy_send_local_response(uint32_t response_code, const char *response_code_details_ptr,
@@ -104,28 +100,27 @@ proxy_send_local_response(uint32_t response_code, const char *response_code_deta
                           const char *additional_response_header_pairs_ptr,
                           size_t additional_response_header_pairs_size, uint32_t grpc_status) {
   return wordToWasmResult(exports::send_local_response(
-      current_context_, WS(response_code), WR(response_code_details_ptr),
-      WS(response_code_details_size), WR(body_ptr), WS(body_size),
-      WR(additional_response_header_pairs_ptr), WS(additional_response_header_pairs_size),
-      WS(grpc_status)));
+      WS(response_code), WR(response_code_details_ptr), WS(response_code_details_size),
+      WR(body_ptr), WS(body_size), WR(additional_response_header_pairs_ptr),
+      WS(additional_response_header_pairs_size), WS(grpc_status)));
 }
 
 inline WasmResult proxy_clear_route_cache() {
-  return wordToWasmResult(exports::clear_route_cache(current_context_));
+  return wordToWasmResult(exports::clear_route_cache());
 }
 
 // SharedData
 inline WasmResult proxy_get_shared_data(const char *key_ptr, size_t key_size,
                                         const char **value_ptr, size_t *value_size, uint32_t *cas) {
-  return wordToWasmResult(exports::get_shared_data(current_context_, WR(key_ptr), WS(key_size),
-                                                   WR(value_ptr), WR(value_size), WR(cas)));
+  return wordToWasmResult(
+      exports::get_shared_data(WR(key_ptr), WS(key_size), WR(value_ptr), WR(value_size), WR(cas)));
 }
 //  If cas != 0 and cas != the current cas for 'key' return false, otherwise set the value and
 //  return true.
 inline WasmResult proxy_set_shared_data(const char *key_ptr, size_t key_size, const char *value_ptr,
                                         size_t value_size, uint64_t cas) {
-  return wordToWasmResult(exports::set_shared_data(current_context_, WR(key_ptr), WS(key_size),
-                                                   WR(value_ptr), WS(value_size), WS(cas)));
+  return wordToWasmResult(
+      exports::set_shared_data(WR(key_ptr), WS(key_size), WR(value_ptr), WS(value_size), WS(cas)));
 }
 
 // SharedQueue
@@ -134,84 +129,77 @@ inline WasmResult proxy_set_shared_data(const char *key_ptr, size_t key_size, co
 // proxy_dequeue_shared_queue. Returns unique token for the queue.
 inline WasmResult proxy_register_shared_queue(const char *queue_name_ptr, size_t queue_name_size,
                                               uint32_t *token) {
-  return wordToWasmResult(exports::register_shared_queue(current_context_, WR(queue_name_ptr),
-                                                         WS(queue_name_size), WR(token)));
+  return wordToWasmResult(
+      exports::register_shared_queue(WR(queue_name_ptr), WS(queue_name_size), WR(token)));
 }
 // Returns unique token for the queue.
 inline WasmResult proxy_resolve_shared_queue(const char *vm_id_ptr, size_t vm_id_size,
                                              const char *queue_name_ptr, size_t queue_name_size,
                                              uint32_t *token) {
-  return wordToWasmResult(exports::resolve_shared_queue(current_context_, WR(vm_id_ptr),
-                                                        WS(vm_id_size), WR(queue_name_ptr),
-                                                        WS(queue_name_size), WR(token)));
+  return wordToWasmResult(exports::resolve_shared_queue(
+      WR(vm_id_ptr), WS(vm_id_size), WR(queue_name_ptr), WS(queue_name_size), WR(token)));
 }
 // Returns true on end-of-stream (no more data available).
 inline WasmResult proxy_dequeue_shared_queue(uint32_t token, const char **data_ptr,
                                              size_t *data_size) {
-  return wordToWasmResult(
-      exports::dequeue_shared_queue(current_context_, WS(token), WR(data_ptr), WR(data_size)));
+  return wordToWasmResult(exports::dequeue_shared_queue(WS(token), WR(data_ptr), WR(data_size)));
 }
 // Returns false if the queue was not found and the data was not enqueued.
 inline WasmResult proxy_enqueue_shared_queue(uint32_t token, const char *data_ptr,
                                              size_t data_size) {
-  return wordToWasmResult(
-      exports::enqueue_shared_queue(current_context_, WS(token), WR(data_ptr), WS(data_size)));
+  return wordToWasmResult(exports::enqueue_shared_queue(WS(token), WR(data_ptr), WS(data_size)));
 }
 
 // Buffer
 inline WasmResult proxy_get_buffer_bytes(WasmBufferType type, uint64_t start, uint64_t length,
                                          const char **ptr, size_t *size) {
-  return wordToWasmResult(exports::get_buffer_bytes(current_context_, WS(type), WS(start),
-                                                    WS(length), WR(ptr), WR(size)));
+  return wordToWasmResult(
+      exports::get_buffer_bytes(WS(type), WS(start), WS(length), WR(ptr), WR(size)));
 }
 
 inline WasmResult proxy_get_buffer_status(WasmBufferType type, size_t *length_ptr,
                                           uint32_t *flags_ptr) {
-  return wordToWasmResult(
-      exports::get_buffer_status(current_context_, WS(type), WR(length_ptr), WR(flags_ptr)));
+  return wordToWasmResult(exports::get_buffer_status(WS(type), WR(length_ptr), WR(flags_ptr)));
 }
 
 inline WasmResult proxy_set_buffer_bytes(WasmBufferType type, uint64_t start, uint64_t length,
                                          const char *data, size_t size) {
-  return wordToWasmResult(exports::set_buffer_bytes(current_context_, WS(type), WS(start),
-                                                    WS(length), WR(data), WS(size)));
+  return wordToWasmResult(
+      exports::set_buffer_bytes(WS(type), WS(start), WS(length), WR(data), WS(size)));
 }
 
 // Headers/Trailers/Metadata Maps
 inline WasmResult proxy_add_header_map_value(WasmHeaderMapType type, const char *key_ptr,
                                              size_t key_size, const char *value_ptr,
                                              size_t value_size) {
-  return wordToWasmResult(exports::add_header_map_value(
-      current_context_, WS(type), WR(key_ptr), WS(key_size), WR(value_ptr), WS(value_size)));
+  return wordToWasmResult(exports::add_header_map_value(WS(type), WR(key_ptr), WS(key_size),
+                                                        WR(value_ptr), WS(value_size)));
 }
 inline WasmResult proxy_get_header_map_value(WasmHeaderMapType type, const char *key_ptr,
                                              size_t key_size, const char **value_ptr,
                                              size_t *value_size) {
-  return wordToWasmResult(exports::get_header_map_value(
-      current_context_, WS(type), WR(key_ptr), WS(key_size), WR(value_ptr), WR(value_size)));
+  return wordToWasmResult(exports::get_header_map_value(WS(type), WR(key_ptr), WS(key_size),
+                                                        WR(value_ptr), WR(value_size)));
 }
 inline WasmResult proxy_get_header_map_pairs(WasmHeaderMapType type, const char **ptr,
                                              size_t *size) {
-  return wordToWasmResult(
-      exports::get_header_map_pairs(current_context_, WS(type), WR(ptr), WR(size)));
+  return wordToWasmResult(exports::get_header_map_pairs(WS(type), WR(ptr), WR(size)));
 }
 inline WasmResult proxy_set_header_map_pairs(WasmHeaderMapType type, const char *ptr, size_t size) {
-  return wordToWasmResult(
-      exports::set_header_map_pairs(current_context_, WS(type), WR(ptr), WS(size)));
+  return wordToWasmResult(exports::set_header_map_pairs(WS(type), WR(ptr), WS(size)));
 }
 inline WasmResult proxy_replace_header_map_value(WasmHeaderMapType type, const char *key_ptr,
                                                  size_t key_size, const char *value_ptr,
                                                  size_t value_size) {
-  return wordToWasmResult(exports::replace_header_map_value(
-      current_context_, WS(type), WR(key_ptr), WS(key_size), WR(value_ptr), WS(value_size)));
+  return wordToWasmResult(exports::replace_header_map_value(WS(type), WR(key_ptr), WS(key_size),
+                                                            WR(value_ptr), WS(value_size)));
 }
 inline WasmResult proxy_remove_header_map_value(WasmHeaderMapType type, const char *key_ptr,
                                                 size_t key_size) {
-  return wordToWasmResult(
-      exports::remove_header_map_value(current_context_, WS(type), WR(key_ptr), WS(key_size)));
+  return wordToWasmResult(exports::remove_header_map_value(WS(type), WR(key_ptr), WS(key_size)));
 }
 inline WasmResult proxy_get_header_map_size(WasmHeaderMapType type, size_t *size) {
-  return wordToWasmResult(exports::get_header_map_size(current_context_, WS(type), WR(size)));
+  return wordToWasmResult(exports::get_header_map_size(WS(type), WR(size)));
 }
 
 // HTTP
@@ -220,10 +208,10 @@ inline WasmResult proxy_http_call(const char *uri_ptr, size_t uri_size, void *he
                                   size_t header_pairs_size, const char *body_ptr, size_t body_size,
                                   void *trailer_pairs_ptr, size_t trailer_pairs_size,
                                   uint64_t timeout_milliseconds, uint32_t *token_ptr) {
-  return wordToWasmResult(
-      exports::http_call(current_context_, WR(uri_ptr), WS(uri_size), WR(header_pairs_ptr),
-                         WS(header_pairs_size), WR(body_ptr), WS(body_size), WR(trailer_pairs_ptr),
-                         WS(trailer_pairs_size), WS(timeout_milliseconds), WR(token_ptr)));
+  return wordToWasmResult(exports::http_call(WR(uri_ptr), WS(uri_size), WR(header_pairs_ptr),
+                                             WS(header_pairs_size), WR(body_ptr), WS(body_size),
+                                             WR(trailer_pairs_ptr), WS(trailer_pairs_size),
+                                             WS(timeout_milliseconds), WR(token_ptr)));
 }
 // gRPC
 // Returns token, used in gRPC callbacks (onGrpc...)
@@ -234,7 +222,7 @@ inline WasmResult proxy_grpc_call(const char *service_ptr, size_t service_size,
                                   const char *request_ptr, size_t request_size,
                                   uint64_t timeout_milliseconds, uint32_t *token_ptr) {
   return wordToWasmResult(
-      exports::grpc_call(current_context_, WR(service_ptr), WS(service_size), WR(service_name_ptr),
+      exports::grpc_call(WR(service_ptr), WS(service_size), WR(service_name_ptr),
                          WS(service_name_size), WR(method_name_ptr), WS(method_name_size),
                          WR(initial_metadata_ptr), WS(initial_metadata_size), WR(request_ptr),
                          WS(request_size), WS(timeout_milliseconds), WR(token_ptr)));
@@ -244,52 +232,52 @@ inline WasmResult proxy_grpc_stream(const char *service_ptr, size_t service_size
                                     const char *method_name_ptr, size_t method_name_size,
                                     void *initial_metadata_ptr, size_t initial_metadata_size,
                                     uint32_t *token_ptr) {
-  return wordToWasmResult(exports::grpc_stream(
-      current_context_, WR(service_ptr), WS(service_size), WR(service_name_ptr),
-      WS(service_name_size), WR(method_name_ptr), WS(method_name_size), WR(initial_metadata_ptr),
-      WS(initial_metadata_size), WR(token_ptr)));
+  return wordToWasmResult(
+      exports::grpc_stream(WR(service_ptr), WS(service_size), WR(service_name_ptr),
+                           WS(service_name_size), WR(method_name_ptr), WS(method_name_size),
+                           WR(initial_metadata_ptr), WS(initial_metadata_size), WR(token_ptr)));
 }
 inline WasmResult proxy_grpc_cancel(uint64_t token) {
-  return wordToWasmResult(exports::grpc_cancel(current_context_, WS(token)));
+  return wordToWasmResult(exports::grpc_cancel(WS(token)));
 }
 inline WasmResult proxy_grpc_close(uint64_t token) {
-  return wordToWasmResult(exports::grpc_close(current_context_, WS(token)));
+  return wordToWasmResult(exports::grpc_close(WS(token)));
 }
 inline WasmResult proxy_grpc_send(uint64_t token, const char *message_ptr, size_t message_size,
                                   uint64_t end_stream) {
-  return wordToWasmResult(exports::grpc_send(current_context_, WS(token), WR(message_ptr),
-                                             WS(message_size), WS(end_stream)));
+  return wordToWasmResult(
+      exports::grpc_send(WS(token), WR(message_ptr), WS(message_size), WS(end_stream)));
 }
 
 // Metrics
 // Returns a metric_id which can be used to report a metric. On error returns 0.
 inline WasmResult proxy_define_metric(MetricType type, const char *name_ptr, size_t name_size,
                                       uint32_t *metric_id) {
-  return wordToWasmResult(exports::define_metric(current_context_, WS(type), WR(name_ptr),
-                                                 WS(name_size), WR(metric_id)));
+  return wordToWasmResult(
+      exports::define_metric(WS(type), WR(name_ptr), WS(name_size), WR(metric_id)));
 }
 inline WasmResult proxy_increment_metric(uint32_t metric_id, int64_t offset) {
-  return wordToWasmResult(exports::increment_metric(current_context_, WS(metric_id), offset));
+  return wordToWasmResult(exports::increment_metric(WS(metric_id), offset));
 }
 inline WasmResult proxy_record_metric(uint32_t metric_id, uint64_t value) {
-  return wordToWasmResult(exports::record_metric(current_context_, WS(metric_id), value));
+  return wordToWasmResult(exports::record_metric(WS(metric_id), value));
 }
 inline WasmResult proxy_get_metric(uint32_t metric_id, uint64_t *value) {
-  return wordToWasmResult(exports::get_metric(current_context_, WS(metric_id), WR(value)));
+  return wordToWasmResult(exports::get_metric(WS(metric_id), WR(value)));
 }
 
 // System
 inline WasmResult proxy_set_effective_context(uint64_t context_id) {
-  return wordToWasmResult(exports::set_effective_context(current_context_, WS(context_id)));
+  return wordToWasmResult(exports::set_effective_context(WS(context_id)));
 }
-inline WasmResult proxy_done() { return wordToWasmResult(exports::done(current_context_)); }
+inline WasmResult proxy_done() { return wordToWasmResult(exports::done()); }
 
 inline WasmResult proxy_call_foreign_function(const char *function_name, size_t function_name_size,
                                               const char *arguments, size_t arguments_size,
                                               char **results, size_t *results_size) {
-  return wordToWasmResult(exports::call_foreign_function(
-      current_context_, WR(function_name), WS(function_name_size), WR(arguments),
-      WS(arguments_size), WR(results), WR(results_size)));
+  return wordToWasmResult(exports::call_foreign_function(WR(function_name), WS(function_name_size),
+                                                         WR(arguments), WS(arguments_size),
+                                                         WR(results), WR(results_size)));
 }
 
 #undef WS

--- a/include/proxy-wasm/wasm_vm.h
+++ b/include/proxy-wasm/wasm_vm.h
@@ -29,37 +29,42 @@ namespace proxy_wasm {
 
 class ContextBase;
 
-// These are templates and its helper for constructing signatures of functions calling into and out
-// of WASM VMs.
-// - WasmFuncTypeHelper is a helper for WasmFuncType and shouldn't be used anywhere else than
+// These are templates and its helper for constructing signatures of functions calling into Wasm
+// VMs.
+// - WasmCallInFuncTypeHelper is a helper for WasmFuncType and shouldn't be used anywhere else than
 // WasmFuncType definition.
-// - WasmFuncType takes 4 template parameter which are number of argument, return type, context type
-// and param type respectively, resolve to a function type.
+// - WasmCallInFuncType takes 4 template parameter which are number of argument, return type,
+// context type and param type respectively, resolve to a function type.
 //   For example `WasmFuncType<3, void, Context*, Word>` resolves to `void(Context*, Word, Word,
 //   Word)`
 template <size_t N, class ReturnType, class ContextType, class ParamType,
           class FuncBase = ReturnType(ContextType)>
-struct WasmFuncTypeHelper {};
+struct WasmCallInFuncTypeHelper {};
 
 template <size_t N, class ReturnType, class ContextType, class ParamType, class... Args>
-struct WasmFuncTypeHelper<N, ReturnType, ContextType, ParamType, ReturnType(ContextType, Args...)> {
+struct WasmCallInFuncTypeHelper<N, ReturnType, ContextType, ParamType,
+                                ReturnType(ContextType, Args...)> {
   // NOLINTNEXTLINE(readability-identifier-naming)
-  using type = typename WasmFuncTypeHelper<N - 1, ReturnType, ContextType, ParamType,
-                                           ReturnType(ContextType, Args..., ParamType)>::type;
+  using type = typename WasmCallInFuncTypeHelper<N - 1, ReturnType, ContextType, ParamType,
+                                                 ReturnType(ContextType, Args..., ParamType)>::type;
 };
 
 template <class ReturnType, class ContextType, class ParamType, class... Args>
-struct WasmFuncTypeHelper<0, ReturnType, ContextType, ParamType, ReturnType(ContextType, Args...)> {
+struct WasmCallInFuncTypeHelper<0, ReturnType, ContextType, ParamType,
+                                ReturnType(ContextType, Args...)> {
   using type = ReturnType(ContextType, Args...); // NOLINT(readability-identifier-naming)
 };
 
 template <size_t N, class ReturnType, class ContextType, class ParamType>
-using WasmFuncType = typename WasmFuncTypeHelper<N, ReturnType, ContextType, ParamType>::type;
+using WasmCallInFuncType =
+    typename WasmCallInFuncTypeHelper<N, ReturnType, ContextType, ParamType>::type;
 
 // Calls into the WASM VM.
 // 1st arg is always a pointer to Context (Context*).
-template <size_t N> using WasmCallVoid = std::function<WasmFuncType<N, void, ContextBase *, Word>>;
-template <size_t N> using WasmCallWord = std::function<WasmFuncType<N, Word, ContextBase *, Word>>;
+template <size_t N>
+using WasmCallVoid = std::function<WasmCallInFuncType<N, void, ContextBase *, Word>>;
+template <size_t N>
+using WasmCallWord = std::function<WasmCallInFuncType<N, Word, ContextBase *, Word>>;
 
 #define FOR_ALL_WASM_VM_EXPORTS(_f)                                                                \
   _f(proxy_wasm::WasmCallVoid<0>) _f(proxy_wasm::WasmCallVoid<1>) _f(proxy_wasm::WasmCallVoid<2>)  \
@@ -67,20 +72,44 @@ template <size_t N> using WasmCallWord = std::function<WasmFuncType<N, Word, Con
           _f(proxy_wasm::WasmCallWord<1>) _f(proxy_wasm::WasmCallWord<2>)                          \
               _f(proxy_wasm::WasmCallWord<3>)
 
+// These are templates and its helper for constructing signatures of functions callbacks from Wasm
+// VMs.
+// - WasmCallbackFuncTypeHelper is a helper for WasmFuncType and shouldn't be used anywhere else
+// than WasmFuncType definition.
+// - WasmCallbackFuncType takes 3 template parameter which are number of argument, return type, and
+// param type respectively, resolve to a function type.
+//   For example `WasmFuncType<3, Word>` resolves to `void(Word, Word, Word)`
+template <size_t N, class ReturnType, class ParamType, class FuncBase = ReturnType()>
+struct WasmCallbackFuncTypeHelper {};
+
+template <size_t N, class ReturnType, class ParamType, class... Args>
+struct WasmCallbackFuncTypeHelper<N, ReturnType, ParamType, ReturnType(Args...)> {
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  using type = typename WasmCallbackFuncTypeHelper<N - 1, ReturnType, ParamType,
+                                                   ReturnType(Args..., ParamType)>::type;
+};
+
+template <class ReturnType, class ParamType, class... Args>
+struct WasmCallbackFuncTypeHelper<0, ReturnType, ParamType, ReturnType(Args...)> {
+  using type = ReturnType(Args...); // NOLINT(readability-identifier-naming)
+};
+
+template <size_t N, class ReturnType, class ParamType>
+using WasmCallbackFuncType = typename WasmCallbackFuncTypeHelper<N, ReturnType, ParamType>::type;
+
 // Calls out of the WASM VM.
-// 1st arg is always a pointer to raw_context (void*).
-template <size_t N> using WasmCallbackVoid = WasmFuncType<N, void, void *, Word> *;
-template <size_t N> using WasmCallbackWord = WasmFuncType<N, Word, void *, Word> *;
+template <size_t N> using WasmCallbackVoid = WasmCallbackFuncType<N, void, Word> *;
+template <size_t N> using WasmCallbackWord = WasmCallbackFuncType<N, Word, Word> *;
 
 // Using the standard g++/clang mangling algorithm:
 // https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling-builtin
 // Extended with W = Word
 // Z = void, j = uint32_t, l = int64_t, m = uint64_t
-using WasmCallback_WWl = Word (*)(void *, Word, int64_t);
-using WasmCallback_WWlWW = Word (*)(void *, Word, int64_t, Word, Word);
-using WasmCallback_WWm = Word (*)(void *, Word, uint64_t);
-using WasmCallback_WWmW = Word (*)(void *, Word, uint64_t, Word);
-using WasmCallback_dd = double (*)(void *, double);
+using WasmCallback_WWl = Word (*)(Word, int64_t);
+using WasmCallback_WWlWW = Word (*)(Word, int64_t, Word, Word);
+using WasmCallback_WWm = Word (*)(Word, uint64_t);
+using WasmCallback_WWmW = Word (*)(Word, uint64_t, Word);
+using WasmCallback_dd = double (*)(double);
 
 #define FOR_ALL_WASM_VM_IMPORTS(_f)                                                                \
   _f(proxy_wasm::WasmCallbackVoid<0>) _f(proxy_wasm::WasmCallbackVoid<1>)                          \

--- a/src/wamr/wamr.cc
+++ b/src/wamr/wamr.cc
@@ -88,11 +88,11 @@ public:
 private:
   template <typename... Args>
   void registerHostFunctionImpl(std::string_view module_name, std::string_view function_name,
-                                void (*function)(void *, Args...));
+                                void (*function)(Args...));
 
   template <typename R, typename... Args>
   void registerHostFunctionImpl(std::string_view module_name, std::string_view function_name,
-                                R (*function)(void *, Args...));
+                                R (*function)(Args...));
 
   template <typename... Args>
   void getModuleFunctionImpl(std::string_view function_name,
@@ -442,7 +442,7 @@ template <typename T> WasmFunctypePtr newWasmNewFuncType() {
 
 template <typename... Args>
 void Wamr::registerHostFunctionImpl(std::string_view module_name, std::string_view function_name,
-                                    void (*function)(void *, Args...)) {
+                                    void (*function)(Args...)) {
   auto data =
       std::make_unique<HostFuncData>(std::string(module_name) + "." + std::string(function_name));
 
@@ -456,9 +456,8 @@ void Wamr::registerHostFunctionImpl(std::string_view module_name, std::string_vi
           func_data->vm_->integration()->trace("[vm->host] " + func_data->name_ + "(" +
                                                printValues(params, sizeof...(Args)) + ")");
         }
-        auto args_tuple = convertValTypesToArgsTuple<std::tuple<Args...>>(params);
-        auto args = std::tuple_cat(std::make_tuple(current_context_), args_tuple);
-        auto fn = reinterpret_cast<void (*)(void *, Args...)>(func_data->raw_func_);
+        auto args = convertValTypesToArgsTuple<std::tuple<Args...>>(params);
+        auto fn = reinterpret_cast<void (*)(Args...)>(func_data->raw_func_);
         std::apply(fn, args);
         if (log) {
           func_data->vm_->integration()->trace("[vm<-host] " + func_data->name_ + " return: void");
@@ -476,7 +475,7 @@ void Wamr::registerHostFunctionImpl(std::string_view module_name, std::string_vi
 
 template <typename R, typename... Args>
 void Wamr::registerHostFunctionImpl(std::string_view module_name, std::string_view function_name,
-                                    R (*function)(void *, Args...)) {
+                                    R (*function)(Args...)) {
   auto data =
       std::make_unique<HostFuncData>(std::string(module_name) + "." + std::string(function_name));
   WasmFunctypePtr type = newWasmNewFuncType<R, std::tuple<Args...>>();
@@ -489,9 +488,8 @@ void Wamr::registerHostFunctionImpl(std::string_view module_name, std::string_vi
           func_data->vm_->integration()->trace("[vm->host] " + func_data->name_ + "(" +
                                                printValues(params, sizeof...(Args)) + ")");
         }
-        auto args_tuple = convertValTypesToArgsTuple<std::tuple<Args...>>(params);
-        auto args = std::tuple_cat(std::make_tuple(current_context_), args_tuple);
-        auto fn = reinterpret_cast<R (*)(void *, Args...)>(func_data->raw_func_);
+        auto args = convertValTypesToArgsTuple<std::tuple<Args...>>(params);
+        auto fn = reinterpret_cast<R (*)(Args...)>(func_data->raw_func_);
         R res = std::apply(fn, args);
         assignVal<R>(res, results[0]);
         if (log) {

--- a/src/wavm/wavm.cc
+++ b/src/wavm/wavm.cc
@@ -359,10 +359,9 @@ std::string_view Wavm::getPrecompiledSectionName() { return "wavm.precompiled_ob
 
 std::unique_ptr<WasmVm> createWavmVm() { return std::make_unique<proxy_wasm::Wavm::Wavm>(); }
 
-template <typename R, typename... Args>
-IR::FunctionType inferHostFunctionType(R (*)(void *, Args...)) {
+template <typename R, typename... Args> IR::FunctionType inferHostFunctionType(R (*)(Args...)) {
   return IR::FunctionType(IR::inferResultType<R>(), IR::TypeTuple({IR::inferValueType<Args>()...}),
-                          IR::CallingConvention::intrinsic);
+                          IR::CallingConvention::c);
 }
 
 using namespace Wavm;

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -179,6 +179,12 @@ TEST_P(TestVM, Trap) {
 }
 
 TEST_P(TestVM, Trap2) {
+  if (runtime_ == "wavm") {
+    // TODO(mathetake): Somehow WAVM exits with 'munmap_chunk(): invalid pointer' on unidentified
+    // build condition in 'libstdc++ abi::__cxa_demangle' originally from
+    // WAVM::Runtime::describeCallStack. Needs further investigation.
+    return;
+  }
   initialize("trap.wasm");
   ASSERT_TRUE(vm_->load(source_, {}, {}));
   ASSERT_TRUE(vm_->link(""));

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -98,14 +98,14 @@ public:
   int64_t counter = 0;
 };
 
-void nopCallback(void *raw_context) {}
+void nopCallback() {}
 
-void callback(void *) {
-  TestContext *context = static_cast<TestContext *>(current_context_);
+void callback() {
+  TestContext *context = static_cast<TestContext *>(contextOrEffectiveContext());
   context->increment();
 }
 
-Word callback2(void *, Word val) { return val + 100; }
+Word callback2(Word val) { return val + 100; }
 
 TEST_P(TestVM, StraceLogLevel) {
   if (runtime_ == "wavm") {
@@ -140,7 +140,6 @@ TEST_P(TestVM, Callback) {
   ASSERT_TRUE(vm_->load(source_, {}, {}));
 
   TestContext context;
-  current_context_ = &context;
 
   vm_->registerCallback(
       "env", "callback", &callback,
@@ -156,13 +155,13 @@ TEST_P(TestVM, Callback) {
   vm_->getFunction("run", &run);
   EXPECT_TRUE(run != nullptr);
   for (auto i = 0; i < 100; i++) {
-    run(current_context_);
+    run(&context);
   }
   ASSERT_EQ(context.counter, 100);
 
   WasmCallWord<1> run2;
   vm_->getFunction("run2", &run2);
-  Word res = run2(current_context_, Word{0});
+  Word res = run2(&context, Word{0});
   ASSERT_EQ(res.u32(), 100100); // 10000 (global) + 100(in callback)
 }
 
@@ -171,31 +170,23 @@ TEST_P(TestVM, Trap) {
   ASSERT_TRUE(vm_->load(source_, {}, {}));
   ASSERT_TRUE(vm_->link(""));
   TestContext context;
-  current_context_ = &context;
   WasmCallVoid<0> trigger;
   vm_->getFunction("trigger", &trigger);
   EXPECT_TRUE(trigger != nullptr);
-  trigger(current_context_);
+  trigger(&context);
   std::string exp_message = "Function: trigger failed";
   ASSERT_TRUE(integration_->error_message_.find(exp_message) != std::string::npos);
 }
 
 TEST_P(TestVM, Trap2) {
-  if (runtime_ == "wavm") {
-    // TODO(mathetake): Somehow WAVM exits with 'munmap_chunk(): invalid pointer' on unidentified
-    // build condition in 'libstdc++ abi::__cxa_demangle' originally from
-    // WAVM::Runtime::describeCallStack. Needs further investigation.
-    return;
-  }
   initialize("trap.wasm");
   ASSERT_TRUE(vm_->load(source_, {}, {}));
   ASSERT_TRUE(vm_->link(""));
   TestContext context;
-  current_context_ = &context;
   WasmCallWord<1> trigger2;
   vm_->getFunction("trigger2", &trigger2);
   EXPECT_TRUE(trigger2 != nullptr);
-  trigger2(current_context_, 0);
+  trigger2(&context, 0);
   std::string exp_message = "Function: trigger2 failed";
   ASSERT_TRUE(integration_->error_message_.find(exp_message) != std::string::npos);
 }


### PR DESCRIPTION
This PR deletes unused raw_context arg in host functions which theoretically reduces the cost of each host calls from Wasm VMs.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>