### PR TITLE
refactor: decouple foreign functions from WasmBase.

### DIFF
--- a/include/proxy-wasm/exports.h
+++ b/include/proxy-wasm/exports.h
@@ -30,6 +30,36 @@ class ContextBase;
 
 extern thread_local ContextBase *current_context_;
 
+/**
+ * WasmForeignFunction is used for registering host-specific host functions.
+ * A foreign function can be registered via RegisterForeignFunction and available
+ * to Wasm modules via proxy_call_foreign_function.
+ * @param wasm is the WasmBase which the Wasm module is running on.
+ * @param argument is the view to the argument to the function passed by the module.
+ * @param alloc_result is used to allocate the result data of this foreign function.
+ */
+using WasmForeignFunction = std::function<WasmResult(
+    WasmBase &wasm, std::string_view argument, std::function<void *(size_t size)> alloc_result)>;
+
+/**
+ * Used to get the foreign function registered via RegisterForeignFunction for a given name.
+ * @param function_name is the name used to lookup the foreign function table.
+ * @return a WasmForeignFunction if registered.
+ */
+WasmForeignFunction getForeignFunction(std::string_view function_name);
+
+/**
+ * RegisterForeignFunction is used to register a foreign function in the lookup table
+ * used internally in getForeignFunction.
+ */
+struct RegisterForeignFunction {
+  /**
+   * @param function_name is the key for this foreign function.
+   * @param f is the function instance.
+   */
+  RegisterForeignFunction(std::string function_name, WasmForeignFunction f);
+};
+
 namespace exports {
 
 template <typename Pairs> size_t pairsSize(const Pairs &result) {

--- a/include/proxy-wasm/wasm.h
+++ b/include/proxy-wasm/wasm.h
@@ -34,11 +34,8 @@ namespace proxy_wasm {
 #include "proxy_wasm_common.h"
 
 class ContextBase;
-class WasmBase;
 class WasmHandleBase;
 
-using WasmForeignFunction =
-    std::function<WasmResult(WasmBase &, std::string_view, std::function<void *(size_t size)>)>;
 using WasmVmFactory = std::function<std::unique_ptr<WasmVm>()>;
 using CallOnThreadFunction = std::function<void(std::function<void()>)>;
 
@@ -128,8 +125,6 @@ public:
   // Copy the data in 's' into the VM along with the pointer-size pair. Returns true on success.
   bool copyToPointerSize(std::string_view s, uint64_t ptr_ptr, uint64_t size_ptr);
   template <typename T> bool setDatatype(uint64_t ptr, const T &t);
-
-  WasmForeignFunction getForeignFunction(std::string_view function_name);
 
   void fail(FailState fail_state, std::string_view message) {
     error(message);
@@ -438,9 +433,5 @@ inline bool WasmBase::copyToPointerSize(std::string_view s, uint64_t ptr_ptr, ui
 template <typename T> inline bool WasmBase::setDatatype(uint64_t ptr, const T &t) {
   return wasm_vm_->setMemory(ptr, sizeof(T), &t);
 }
-
-struct RegisterForeignFunction {
-  RegisterForeignFunction(std::string name, WasmForeignFunction f);
-};
 
 } // namespace proxy_wasm

--- a/src/exports.cc
+++ b/src/exports.cc
@@ -37,8 +37,8 @@ ContextBase *contextOrEffectiveContext() {
 extern thread_local uint32_t effective_context_id_;
 
 std::unordered_map<std::string, WasmForeignFunction> &foreignFunctions() {
-    static auto ptr = new std::unordered_map<std::string, WasmForeignFunction>;
-    return *ptr;
+  static auto ptr = new std::unordered_map<std::string, WasmForeignFunction>;
+  return *ptr;
 }
 
 WasmForeignFunction getForeignFunction(std::string_view function_name) {

--- a/src/exports.cc
+++ b/src/exports.cc
@@ -36,22 +36,22 @@ ContextBase *contextOrEffectiveContext() {
 // of current_context_.
 extern thread_local uint32_t effective_context_id_;
 
-// Lookup table of foreign functions, using a pointer to avoid the initialization fiasco.
-std::unordered_map<std::string, WasmForeignFunction> *foreign_functions = nullptr;
+std::unordered_map<std::string, WasmForeignFunction> &foreignFunctions() {
+    static auto ptr = new std::unordered_map<std::string, WasmForeignFunction>;
+    return *ptr;
+}
 
 WasmForeignFunction getForeignFunction(std::string_view function_name) {
-  auto it = foreign_functions->find(std::string(function_name));
-  if (it != foreign_functions->end()) {
+  auto foreign_functions = foreignFunctions();
+  auto it = foreign_functions.find(std::string(function_name));
+  if (it != foreign_functions.end()) {
     return it->second;
   }
   return nullptr;
 }
 
 RegisterForeignFunction::RegisterForeignFunction(std::string name, WasmForeignFunction f) {
-  if (!foreign_functions) {
-    foreign_functions = new std::remove_reference<decltype(*foreign_functions)>::type;
-  }
-  (*foreign_functions)[name] = f;
+  foreignFunctions()[name] = f;
 }
 
 namespace exports {

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -45,7 +45,6 @@ thread_local std::unordered_map<std::string, std::weak_ptr<PluginHandleBase>> lo
 // Map from Wasm Key to the base Wasm instance, using a pointer to avoid the initialization fiasco.
 std::mutex base_wasms_mutex;
 std::unordered_map<std::string, std::weak_ptr<WasmHandleBase>> *base_wasms = nullptr;
-std::unordered_map<std::string, WasmForeignFunction> *foreign_functions = nullptr;
 
 std::vector<uint8_t> Sha256(const std::vector<std::string_view> parts) {
   uint8_t sha256[SHA256_DIGEST_LENGTH];
@@ -84,13 +83,6 @@ public:
 private:
   std::shared_ptr<WasmBase> wasm_;
 };
-
-RegisterForeignFunction::RegisterForeignFunction(std::string name, WasmForeignFunction f) {
-  if (!foreign_functions) {
-    foreign_functions = new std::remove_reference<decltype(*foreign_functions)>::type;
-  }
-  (*foreign_functions)[name] = f;
-}
 
 void WasmBase::registerCallbacks() {
 #define _REGISTER(_fn)                                                                             \
@@ -452,14 +444,6 @@ void WasmBase::finishShutdown() {
     (*it)->onDelete();
     it = pending_delete_.erase(it);
   }
-}
-
-WasmForeignFunction WasmBase::getForeignFunction(std::string_view function_name) {
-  auto it = foreign_functions->find(std::string(function_name));
-  if (it != foreign_functions->end()) {
-    return it->second;
-  }
-  return nullptr;
 }
 
 std::shared_ptr<WasmHandleBase> createWasm(std::string vm_key, std::string code,


### PR DESCRIPTION
It seems unnecessary to have foreign functions managed by WasmBase because it's just using global lookup tables. 

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>