### PR TITLE
Add support for big-endian platforms.

### DIFF
--- a/include/proxy-wasm/exports.h
+++ b/include/proxy-wasm/exports.h
@@ -74,12 +74,12 @@ template <typename Pairs> size_t pairsSize(const Pairs &result) {
 
 template <typename Pairs> void marshalPairs(const Pairs &result, char *buffer) {
   char *b = buffer;
-  *reinterpret_cast<uint32_t *>(b) = result.size();
+  *reinterpret_cast<uint32_t *>(b) = htole32(result.size());
   b += sizeof(uint32_t);
   for (auto &p : result) {
-    *reinterpret_cast<uint32_t *>(b) = p.first.size();
+    *reinterpret_cast<uint32_t *>(b) = htole32(p.first.size());
     b += sizeof(uint32_t);
-    *reinterpret_cast<uint32_t *>(b) = p.second.size();
+    *reinterpret_cast<uint32_t *>(b) = htole32(p.second.size());
     b += sizeof(uint32_t);
   }
   for (auto &p : result) {

--- a/include/proxy-wasm/wasm.h
+++ b/include/proxy-wasm/wasm.h
@@ -421,20 +421,10 @@ inline bool WasmBase::copyToPointerSize(std::string_view s, uint64_t ptr_ptr, ui
     }
     memcpy(p, s.data(), size);
   }
-#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
-    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-  if (!wasm_vm_->setWord(ptr_ptr, Word(__builtin_bswap32(pointer)))) {
-#else
   if (!wasm_vm_->setWord(ptr_ptr, Word(pointer))) {
-#endif
     return false;
   }
-#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
-    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-  if (!wasm_vm_->setWord(size_ptr, Word(__builtin_bswap32(size)))) {
-#else
   if (!wasm_vm_->setWord(size_ptr, Word(size))) {
-#endif
     return false;
   }
   return true;

--- a/include/proxy-wasm/wasm.h
+++ b/include/proxy-wasm/wasm.h
@@ -421,10 +421,20 @@ inline bool WasmBase::copyToPointerSize(std::string_view s, uint64_t ptr_ptr, ui
     }
     memcpy(p, s.data(), size);
   }
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  if (!wasm_vm_->setWord(ptr_ptr, Word(__builtin_bswap32(pointer)))) {
+#else
   if (!wasm_vm_->setWord(ptr_ptr, Word(pointer))) {
+#endif
     return false;
   }
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  if (!wasm_vm_->setWord(size_ptr, Word(__builtin_bswap32(size)))) {
+#else
   if (!wasm_vm_->setWord(size_ptr, Word(size))) {
+#endif
     return false;
   }
   return true;

--- a/include/proxy-wasm/word.h
+++ b/include/proxy-wasm/word.h
@@ -17,6 +17,11 @@
 
 #include <iostream>
 
+#ifdef __APPLE__
+#define htole32(x) (x)
+#define le32toh(x) (x)
+#endif
+
 namespace proxy_wasm {
 
 #include "proxy_wasm_common.h"

--- a/src/exports.cc
+++ b/src/exports.cc
@@ -64,16 +64,33 @@ Pairs toPairs(std::string_view buffer) {
   if (buffer.size() < sizeof(uint32_t)) {
     return {};
   }
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  auto size = __builtin_bswap32(*reinterpret_cast<const uint32_t *>(b));
+#else
   auto size = *reinterpret_cast<const uint32_t *>(b);
+#endif
   b += sizeof(uint32_t);
   if (sizeof(uint32_t) + size * 2 * sizeof(uint32_t) > buffer.size()) {
     return {};
   }
   result.resize(size);
   for (uint32_t i = 0; i < size; i++) {
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    result[i].first =
+        std::string_view(nullptr, __builtin_bswap32(*reinterpret_cast<const uint32_t *>(b)));
+#else
     result[i].first = std::string_view(nullptr, *reinterpret_cast<const uint32_t *>(b));
+#endif
     b += sizeof(uint32_t);
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    result[i].second =
+        std::string_view(nullptr, __builtin_bswap32(*reinterpret_cast<const uint32_t *>(b)));
+#else
     result[i].second = std::string_view(nullptr, *reinterpret_cast<const uint32_t *>(b));
+#endif
     b += sizeof(uint32_t);
   }
   for (auto &p : result) {
@@ -94,10 +111,20 @@ bool getPairs(ContextBase *context, const Pairs &result, uint64_t ptr_ptr, uint6
   uint64_t ptr;
   char *buffer = static_cast<char *>(context->wasm()->allocMemory(size, &ptr));
   marshalPairs(result, buffer);
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  if (!context->wasmVm()->setWord(ptr_ptr, Word(__builtin_bswap32(ptr)))) {
+#else
   if (!context->wasmVm()->setWord(ptr_ptr, Word(ptr))) {
+#endif
     return false;
   }
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  if (!context->wasmVm()->setWord(size_ptr, Word(__builtin_bswap32(size)))) {
+#else
   if (!context->wasmVm()->setWord(size_ptr, Word(size))) {
+#endif
     return false;
   }
   return true;
@@ -257,10 +284,21 @@ Word call_foreign_function(Word function_name, Word function_name_size, Word arg
     result_size = s;
     return result;
   });
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  if (results && !context->wasmVm()->setWord(results, Word(__builtin_bswap32(address)))) {
+#else
   if (results && !context->wasmVm()->setWord(results, Word(address))) {
+#endif
     return WasmResult::InvalidMemoryAccess;
   }
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  if (results_size &&
+      !context->wasmVm()->setWord(results_size, Word(__builtin_bswap32(result_size)))) {
+#else
   if (results_size && !context->wasmVm()->setWord(results_size, Word(result_size))) {
+#endif
     return WasmResult::InvalidMemoryAccess;
   }
   if (!results) {
@@ -462,7 +500,12 @@ Word get_header_map_size(Word type, Word result_ptr) {
   if (result != WasmResult::Ok) {
     return result;
   }
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  if (!context->wasmVm()->setWord(result_ptr, Word(__builtin_bswap32(size)))) {
+#else
   if (!context->wasmVm()->setWord(result_ptr, Word(size))) {
+#endif
     return WasmResult::InvalidMemoryAccess;
   }
   return WasmResult::Ok;
@@ -503,7 +546,12 @@ Word get_buffer_status(Word type, Word length_ptr, Word flags_ptr) {
   }
   auto length = buffer->size();
   uint32_t flags = 0;
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  if (!context->wasmVm()->setWord(length_ptr, Word(__builtin_bswap32(length)))) {
+#else
   if (!context->wasmVm()->setWord(length_ptr, Word(length))) {
+#endif
     return WasmResult::InvalidMemoryAccess;
   }
   if (!context->wasm()->setDatatype(flags_ptr, flags)) {
@@ -712,7 +760,13 @@ Word writevImpl(Word fd, Word iovs, Word iovs_len, Word *nwritten_ptr) {
     }
     const uint32_t *iovec = reinterpret_cast<const uint32_t *>(memslice.value().data());
     if (iovec[1] /* buf_len */) {
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+      memslice = context->wasmVm()->getMemory(__builtin_bswap32(iovec[0]) /* buf */,
+                                              __builtin_bswap32(iovec[1]) /* buf_len */);
+#else
       memslice = context->wasmVm()->getMemory(iovec[0] /* buf */, iovec[1] /* buf_len */);
+#endif
       if (!memslice) {
         return 21; // __WASI_EFAULT
       }
@@ -744,7 +798,12 @@ Word wasi_unstable_fd_write(Word fd, Word iovs, Word iovs_len, Word nwritten_ptr
   if (result != 0) { // __WASI_ESUCCESS
     return result;
   }
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  if (!context->wasmVm()->setWord(nwritten_ptr, Word(__builtin_bswap32(nwritten)))) {
+#else
   if (!context->wasmVm()->setWord(nwritten_ptr, Word(nwritten))) {
+#endif
     return 21; // __WASI_EFAULT
   }
   return 0; // __WASI_ESUCCESS
@@ -798,7 +857,12 @@ Word wasi_unstable_environ_get(Word environ_array_ptr, Word environ_buf) {
   auto word_size = context->wasmVm()->getWordSize();
   auto &envs = context->wasm()->envs();
   for (auto e : envs) {
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    if (!context->wasmVm()->setWord(environ_array_ptr, __builtin_bswap32(environ_buf))) {
+#else
     if (!context->wasmVm()->setWord(environ_array_ptr, environ_buf)) {
+#endif
       return 21; // __WASI_EFAULT
     }
 
@@ -823,7 +887,12 @@ Word wasi_unstable_environ_get(Word environ_array_ptr, Word environ_buf) {
 Word wasi_unstable_environ_sizes_get(Word count_ptr, Word buf_size_ptr) {
   auto context = contextOrEffectiveContext();
   auto &envs = context->wasm()->envs();
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  if (!context->wasmVm()->setWord(count_ptr, Word(__builtin_bswap32(envs.size())))) {
+#else
   if (!context->wasmVm()->setWord(count_ptr, Word(envs.size()))) {
+#endif
     return 21; // __WASI_EFAULT
   }
 
@@ -832,7 +901,12 @@ Word wasi_unstable_environ_sizes_get(Word count_ptr, Word buf_size_ptr) {
     // len(key) + len(value) + 1('=') + 1(null terminator)
     size += e.first.size() + e.second.size() + 2;
   }
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  if (!context->wasmVm()->setWord(buf_size_ptr, Word(__builtin_bswap32(size)))) {
+#else
   if (!context->wasmVm()->setWord(buf_size_ptr, Word(size))) {
+#endif
     return 21; // __WASI_EFAULT
   }
   return 0; // __WASI_ESUCCESS

--- a/src/v8/v8.cc
+++ b/src/v8/v8.cc
@@ -432,7 +432,7 @@ bool V8::getWord(uint64_t pointer, Word *word) {
   }
   uint32_t word32;
   ::memcpy(&word32, memory_->data() + pointer, size);
-  word->u64_ = word32;
+  word->u64_ = le32toh(word32);
   return true;
 }
 
@@ -441,7 +441,7 @@ bool V8::setWord(uint64_t pointer, Word word) {
   if (pointer + size > memory_->data_size()) {
     return false;
   }
-  uint32_t word32 = word.u32();
+  uint32_t word32 = htole32(word.u32());
   ::memcpy(memory_->data() + pointer, &word32, size);
   return true;
 }

--- a/src/wamr/wamr.cc
+++ b/src/wamr/wamr.cc
@@ -340,7 +340,7 @@ bool Wamr::getWord(uint64_t pointer, Word *word) {
 
   uint32_t word32;
   ::memcpy(&word32, wasm_memory_data(memory_.get()) + pointer, size);
-  word->u64_ = word32;
+  word->u64_ = le32toh(word32);
   return true;
 }
 
@@ -349,7 +349,7 @@ bool Wamr::setWord(uint64_t pointer, Word word) {
   if (pointer + size > wasm_memory_data_size(memory_.get())) {
     return false;
   }
-  uint32_t word32 = word.u32();
+  uint32_t word32 = htole32(word.u32());
   ::memcpy(wasm_memory_data(memory_.get()) + pointer, &word32, size);
   return true;
 }

--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -354,7 +354,7 @@ bool Wasmtime::getWord(uint64_t pointer, Word *word) {
 
   uint32_t word32;
   ::memcpy(&word32, wasm_memory_data(memory_.get()) + pointer, size);
-  word->u64_ = word32;
+  word->u64_ = le32toh(word32);
   return true;
 }
 
@@ -363,7 +363,7 @@ bool Wasmtime::setWord(uint64_t pointer, Word word) {
   if (pointer + size > wasm_memory_data_size(memory_.get())) {
     return false;
   }
-  uint32_t word32 = word.u32();
+  uint32_t word32 = htole32(word.u32());
   ::memcpy(wasm_memory_data(memory_.get()) + pointer, &word32, size);
   return true;
 }

--- a/src/wavm/wavm.cc
+++ b/src/wavm/wavm.cc
@@ -344,12 +344,12 @@ bool Wavm::getWord(uint64_t pointer, Word *data) {
   auto p = reinterpret_cast<char *>(memory_base_ + pointer);
   uint32_t data32;
   memcpy(&data32, p, sizeof(uint32_t));
-  data->u64_ = data32;
+  data->u64_ = le32toh(data32);
   return true;
 }
 
 bool Wavm::setWord(uint64_t pointer, Word data) {
-  uint32_t data32 = data.u32();
+  uint32_t data32 = htole32(data.u32());
   return setMemory(pointer, sizeof(uint32_t), &data32);
 }
 

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -56,7 +56,7 @@ TEST_P(TestVM, Memory) {
   ASSERT_TRUE(vm_->getWord(0x2000, &word));
   ASSERT_EQ(100, word.u64_);
 
-  int32_t data[2] = {-1, 200};
+  uint32_t data[2] = {htole32(static_cast<uint32_t>(-1)), htole32(200)};
   ASSERT_TRUE(vm_->setMemory(0x200, sizeof(int32_t) * 2, static_cast<void *>(data)));
   ASSERT_TRUE(vm_->getWord(0x200, &word));
   ASSERT_EQ(-1, static_cast<int32_t>(word.u64_));


### PR DESCRIPTION
Wasm binary always has Little-endian byte ordering. V8 is hardcoded to reverse the bytes with every wasm load/store operation done on Big-endian machines. But in case of envoy proxy the wasm binary file is linked with envoy C code compiled on a native BE machine. In this case a BE value is being written to LE enforced memory, and the crash happens when running wasm on BE machine. To fix this, everything needs to be written to memory in LE order when linking with any other libraries outside the wasm binary itself.
Resolves https://github.com/proxy-wasm/proxy-wasm-cpp-host/issues/197