### PR TITLE
wasmtime: update C API to v0.32.0.

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -59,9 +59,9 @@ def proxy_wasm_cpp_host_repositories():
     http_archive(
         name = "com_github_bytecodealliance_wasmtime",
         build_file = "@proxy_wasm_cpp_host//bazel/external:wasmtime.BUILD",
-        sha256 = "4f9fc62453f2d8faf2374699a40e95d9265829e675b5a28e45e2af4b642e7219",
-        strip_prefix = "wasmtime-0.31.0",
-        url = "https://github.com/bytecodealliance/wasmtime/archive/v0.31.0.tar.gz",
+        sha256 = "47d823a71c2512f201b772fae73912c22882385197d67ece6855f29393516147",
+        strip_prefix = "wasmtime-0.32.0",
+        url = "https://github.com/bytecodealliance/wasmtime/archive/v0.32.0.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Missed in #205.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>