### PR TITLE
Allow using system's crypto library instead of BoringSSL.

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -69,6 +69,7 @@ jobs:
         - name: 'V8 on Linux'
           runtime: 'v8'
           os: ubuntu-20.04
+          flags: '--define crypto=system'
         - name: 'V8 on macOS'
           runtime: 'v8'
           os: macos-11
@@ -110,11 +111,22 @@ jobs:
 
     - name: Test
       run: |
-        bazel test --test_output=errors --define runtime=${{ matrix.runtime }} //test/...
+        bazel test \
+              --verbose_failures \
+              --test_output=errors \
+              --define runtime=${{ matrix.runtime }} \
+              ${{ matrix.flags }} \
+              //test/...
 
     - name: Test (signed Wasm module)
       run: |
-        bazel test --test_output=errors --define runtime=${{ matrix.runtime }} --per_file_copt=src/signature_util.cc,test/signature_util_test.cc@-DPROXY_WASM_VERIFY_WITH_ED25519_PUBKEY=\"$(xxd -p -c 256 test/test_data/signature_key1.pub | cut -b9-)\" //test:signature_util_test
+        bazel test \
+              --verbose_failures \
+              --test_output=errors \
+              --define runtime=${{ matrix.runtime }} \
+              ${{ matrix.flags }} \
+              --per_file_copt=src/signature_util.cc,test/signature_util_test.cc@-DPROXY_WASM_VERIFY_WITH_ED25519_PUBKEY=\"$(xxd -p -c 256 test/test_data/signature_key1.pub | cut -b9-)\" \
+              //test:signature_util_test
 
     - name: Cleanup Bazel cache
       if: matrix.runtime != 'wasmtime'

--- a/BUILD
+++ b/BUILD
@@ -56,10 +56,16 @@ cc_library(
         "include/proxy-wasm/bytecode_util.h",
         "include/proxy-wasm/signature_util.h",
     ],
+    linkopts = select({
+        "//bazel:crypto_system": ["-lcrypto"],
+        "//conditions:default": [],
+    }),
     deps = [
         ":headers",
-        "@boringssl//:crypto",
-    ],
+    ] + select({
+        "//bazel:crypto_system": [],
+        "//conditions:default": ["@boringssl//:crypto"],
+    }),
 )
 
 cc_library(

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -17,3 +17,8 @@ config_setting(
     name = "runtime_wavm",
     values = {"define": "runtime=wavm"},
 )
+
+config_setting(
+    name = "crypto_system",
+    values = {"define": "crypto=system"},
+)


### PR DESCRIPTION
Use: bazel test --define crypto=system //test/...

Signed-off-by: Piotr Sikora <piotrsikora@google.com>