### PR TITLE
Update BoringSSL to 2022-01-10.

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -25,9 +25,10 @@ def proxy_wasm_cpp_host_repositories():
 
     http_archive(
         name = "boringssl",
-        sha256 = "bb55b0ed2f0cb548b5dce6a6b8307ce37f7f748eb9f1be6bfe2d266ff2b4d52b",
-        strip_prefix = "boringssl-2192bbc878822cf6ab5977d4257a1339453d9d39",
-        urls = ["https://github.com/google/boringssl/archive/2192bbc878822cf6ab5977d4257a1339453d9d39.tar.gz"],
+        # 2022-01-10 (master-with-bazel)
+        sha256 = "a530919e3141d00d593a0d74cd0f9f88707e35ec58bb62245968fec16cb9257f",
+        strip_prefix = "boringssl-9420fb54116466923afa1f34a23dd8a4a7ddb69d",
+        urls = ["https://github.com/google/boringssl/archive/9420fb54116466923afa1f34a23dd8a4a7ddb69d.tar.gz"],
     )
 
     http_archive(


### PR DESCRIPTION
Signed-off-by: Piotr Sikora <piotrsikora@google.com>