### PR TITLE
build: stop installing Ninja.

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -127,14 +127,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install dependency (Linux)
-      if: startsWith(matrix.os, 'ubuntu')
-      run: sudo apt-get install ninja-build
-
-    - name: Install dependency (macOS)
-      if: startsWith(matrix.os, 'macos')
-      run: brew install ninja
-
     - name: Activate Docker/QEMU
       if: startsWith(matrix.run_under, 'docker')
       run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes


### PR DESCRIPTION
rules_foreign_cc is automatically downloading CMake and Ninja.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>