### PR TITLE
v8: increase the maximum number of WasmVMs.

### DIFF
--- a/bazel/external/v8.patch
+++ b/bazel/external/v8.patch
@@ -1,0 +1,15 @@
+# Disable pointer compression (limits the maximum number of WasmVMs).
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 1cc0121e60..4947c1dba2 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -161,7 +161,7 @@ v8_int(
+ # If no explicit value for v8_enable_pointer_compression, we set it to 'none'.
+ v8_string(
+     name = "v8_enable_pointer_compression",
+-    default = "none",
++    default = "False",
+ )
+ 
+ # Default setting for v8_enable_pointer_compression.

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -98,6 +98,8 @@ def proxy_wasm_cpp_host_repositories():
         commit = "90f089d97b6e4146ad106eee1829d86ad6392027",
         remote = "https://chromium.googlesource.com/v8/v8",
         shallow_since = "1643043727 +0000",
+        patches = ["@proxy_wasm_cpp_host//bazel/external:v8.patch"],
+        patch_args = ["-p1"],
     )
 
     native.bind(


### PR DESCRIPTION
New pointer compression features severely limit the maximum number
of WasmVMs that can be created in a single process, so disable it.

See: https://bugs.chromium.org/p/v8/issues/detail?id=12592

This increases the maximum number of WasmVMs from 268 to 6,479.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>