### PR TITLE
ci: skip cache update on PRs.

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -66,7 +66,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Bazel cache
-      uses: actions/cache@v2
+      uses: PiotrSikora/cache@v2.1.7-with-skip-cache
       with:
         path: |
           ~/.cache/bazel
@@ -88,7 +88,12 @@ jobs:
         if-no-files-found: error
         retention-days: 3
 
+    - name: Skip Bazel cache update
+      if: ${{ github.ref != 'refs/heads/master' }}
+      run: echo "CACHE_SKIP_SAVE=true" >> $GITHUB_ENV
+
     - name: Cleanup Bazel cache
+      if: ${{ github.ref == 'refs/heads/master' }}
       run: |
         export OUTPUT=$(bazel info output_base)
         # Distfiles for Rust toolchains (350 MiB).

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -137,7 +137,7 @@ jobs:
 
     - name: Bazel cache
       if: ${{ matrix.runtime != 'wasmtime' || startsWith(matrix.run_under, 'docker') }}
-      uses: actions/cache@v2
+      uses: PiotrSikora/cache@v2.1.7-with-skip-cache
       with:
         path: |
           ~/.cache/bazel
@@ -145,7 +145,6 @@ jobs:
         key: ${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.runtime }}-${{ steps.cache-key.outputs.uniq }}-${{ hashFiles('WORKSPACE', '.bazelrc', '.bazelversion', 'bazel/dependencies.bzl', 'bazel/repositories.bzl') }}
         restore-keys: |
           ${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.runtime }}-${{ steps.cache-key.outputs.uniq }}-
-          ${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.runtime }}
 
     - name: Bazel build/test
       run: >
@@ -169,7 +168,7 @@ jobs:
         //test:signature_util_test
 
     - name: Cleanup Bazel cache
-      if: ${{ matrix.runtime != 'wasmtime' || startsWith(matrix.run_under, 'docker') }}
+      if: ${{ github.ref == 'refs/heads/master' && (matrix.runtime != 'wasmtime' || startsWith(matrix.run_under, 'docker')) }}
       run: |
         export OUTPUT=$(bazel info output_base)
         # BoringSSL's test data (90 MiB).
@@ -191,3 +190,7 @@ jobs:
         # Bazel's repository cache (650-800 MiB) and install base (155 MiB).
         rm -rf $(bazel info repository_cache)
         rm -rf $(bazel info install_base)
+
+    - name: Skip cache update
+      if: ${{ github.ref != 'refs/heads/master' }}
+      run: echo "CACHE_SKIP_SAVE=true" >> $GITHUB_ENV

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -229,7 +229,7 @@ jobs:
         //test:signature_util_test
 
     - name: Skip Bazel cache update
-      if: ${{ github.ref != 'refs/heads/master' }}
+      if: ${{ github.ref != 'refs/heads/master' && (matrix.runtime != 'wasmtime' || startsWith(matrix.run_under, 'docker')) }}
       run: echo "CACHE_SKIP_SAVE=true" >> $GITHUB_ENV
 
     - name: Cleanup Bazel cache

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -167,6 +167,10 @@ jobs:
         --per_file_copt=src/signature_util.cc,test/signature_util_test.cc@-DPROXY_WASM_VERIFY_WITH_ED25519_PUBKEY=\"$(xxd -p -c 256 test/test_data/signature_key1.pub | cut -b9-)\"
         //test:signature_util_test
 
+    - name: Skip Bazel cache update
+      if: ${{ github.ref != 'refs/heads/master' }}
+      run: echo "CACHE_SKIP_SAVE=true" >> $GITHUB_ENV
+
     - name: Cleanup Bazel cache
       if: ${{ github.ref == 'refs/heads/master' && (matrix.runtime != 'wasmtime' || startsWith(matrix.run_under, 'docker')) }}
       run: |
@@ -190,7 +194,3 @@ jobs:
         # Bazel's repository cache (650-800 MiB) and install base (155 MiB).
         rm -rf $(bazel info repository_cache)
         rm -rf $(bazel info install_base)
-
-    - name: Skip cache update
-      if: ${{ github.ref != 'refs/heads/master' }}
-      run: echo "CACHE_SKIP_SAVE=true" >> $GITHUB_ENV


### PR DESCRIPTION
Cache updates on PRs result in early eviction of primary cache,
due to the limited quota on GitHub Actions.

While there, remove fallback to restore cache key based only on
the Wasm runtime name, since it prevents pruning of stale data.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>