### PR TITLE
test: print Wasm engine names in test logs.

### DIFF
--- a/test/exports_test.cc
+++ b/test/exports_test.cc
@@ -30,9 +30,10 @@
 namespace proxy_wasm {
 namespace {
 
-auto test_values = testing::ValuesIn(getRuntimes());
-
-INSTANTIATE_TEST_SUITE_P(Runtimes, TestVM, test_values);
+INSTANTIATE_TEST_SUITE_P(Runtimes, TestVM, testing::ValuesIn(getRuntimes()),
+                         [](const testing::TestParamInfo<std::string> &info) {
+                           return info.param;
+                         });
 
 class TestContext : public ContextBase {
 public:

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -29,9 +29,10 @@
 namespace proxy_wasm {
 namespace {
 
-auto test_values = testing::ValuesIn(getRuntimes());
-
-INSTANTIATE_TEST_SUITE_P(Runtimes, TestVM, test_values);
+INSTANTIATE_TEST_SUITE_P(Runtimes, TestVM, testing::ValuesIn(getRuntimes()),
+                         [](const testing::TestParamInfo<std::string> &info) {
+                           return info.param;
+                         });
 
 TEST_P(TestVM, Basic) {
   if (runtime_ == "wamr") {

--- a/test/utility.cc
+++ b/test/utility.cc
@@ -21,14 +21,14 @@ std::vector<std::string> getRuntimes() {
 #if defined(PROXY_WASM_HAS_RUNTIME_V8)
     "v8",
 #endif
-#if defined(PROXY_WASM_HAS_RUNTIME_WAVM)
-    "wavm",
+#if defined(PROXY_WASM_HAS_RUNTIME_WAMR)
+    "wamr",
 #endif
 #if defined(PROXY_WASM_HAS_RUNTIME_WASMTIME)
     "wasmtime",
 #endif
-#if defined(PROXY_WASM_HAS_RUNTIME_WAMR)
-    "wamr",
+#if defined(PROXY_WASM_HAS_RUNTIME_WAVM)
+    "wavm",
 #endif
     ""
   };

--- a/test/wasm_test.cc
+++ b/test/wasm_test.cc
@@ -20,9 +20,10 @@
 
 namespace proxy_wasm {
 
-auto test_values = testing::ValuesIn(getRuntimes());
-
-INSTANTIATE_TEST_SUITE_P(Runtimes, TestVM, test_values);
+INSTANTIATE_TEST_SUITE_P(Runtimes, TestVM, testing::ValuesIn(getRuntimes()),
+                         [](const testing::TestParamInfo<std::string> &info) {
+                           return info.param;
+                         });
 
 // Failcallbacks only used for runtimes - not available for nullvm.
 TEST_P(TestVM, GetOrCreateThreadLocalWasmFailCallbacks) {


### PR DESCRIPTION
While there, sort them alphabetically.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>