### PR TITLE
wasmtime: split "prefixed_wasmtime" into a separate target.

### DIFF
--- a/bazel/external/wasm-c-api.BUILD
+++ b/bazel/external/wasm-c-api.BUILD
@@ -9,7 +9,6 @@ cc_library(
     hdrs = [
         "include/wasm.h",
     ],
-    include_prefix = "wasmtime",
     deps = [
         "@com_github_bytecodealliance_wasmtime//:rust_c_api",
     ],
@@ -21,7 +20,7 @@ genrule(
         "include/wasm.h",
     ],
     outs = [
-        "wasmtime/include/wasm.h",
+        "include/prefixed_wasm.h",
     ],
     cmd = """
         sed -e 's/\\ wasm_/\\ wasmtime_wasm_/g' \

--- a/bazel/select.bzl
+++ b/bazel/select.bzl
@@ -33,10 +33,10 @@ def proxy_wasm_select_engine_wamr(xs):
         "//conditions:default": [],
     })
 
-def proxy_wasm_select_engine_wasmtime(xs):
+def proxy_wasm_select_engine_wasmtime(xs, xp):
     return select({
         "@proxy_wasm_cpp_host//bazel:engine_wasmtime": xs,
-        "@proxy_wasm_cpp_host//bazel:multiengine": xs,
+        "@proxy_wasm_cpp_host//bazel:multiengine": xp,
         "//conditions:default": [],
     })
 

--- a/src/wasmtime/types.h
+++ b/src/wasmtime/types.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "src/common/types.h"
-#include "wasmtime/include/wasm.h"
+#include "include/wasm.h"
 
 namespace proxy_wasm {
 namespace wasmtime {

--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -26,7 +26,7 @@
 
 #include "src/wasmtime/types.h"
 
-#include "wasmtime/include/wasm.h"
+#include "include/wasm.h"
 
 namespace proxy_wasm {
 namespace wasmtime {


### PR DESCRIPTION
Signed-off-by: Piotr Sikora <piotrsikora@google.com>