### PR TITLE
wasmtime: fix params array getting out of scope.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,7 +172,7 @@ jobs:
           os: ubuntu-20.04
           arch: x86_64
           action: test
-          flags: --config=clang
+          flags: --config=clang -c opt
         - name: 'Wasmtime on Linux/x86_64 with ASan'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'
@@ -180,13 +180,6 @@ jobs:
           arch: x86_64
           action: test
           flags: --config=clang-asan-strict --define=crypto=system
-        - name: 'Wasmtime on Linux/x86_64 with TSan'
-          engine: 'wasmtime'
-          repo: 'com_github_bytecodealliance_wasmtime'
-          os: ubuntu-20.04
-          arch: x86_64
-          action: test
-          flags: --config=clang-tsan
         - name: 'Wasmtime on Linux/aarch64'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,6 +180,13 @@ jobs:
           arch: x86_64
           action: test
           flags: --config=clang-asan-strict --define=crypto=system
+        - name: 'Wasmtime on Linux/x86_64 with TSan'
+          engine: 'wasmtime'
+          repo: 'com_github_bytecodealliance_wasmtime'
+          os: ubuntu-20.04
+          arch: x86_64
+          action: test
+          flags: --config=clang-tsan
         - name: 'Wasmtime on Linux/aarch64'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'

--- a/src/v8/v8.cc
+++ b/src/v8/v8.cc
@@ -585,6 +585,8 @@ void V8::getModuleFunctionImpl(std::string_view function_name,
   *function = [func, function_name, this](ContextBase *context, Args... args) -> void {
     const bool log = cmpLogLevel(LogLevel::trace);
     SaveRestoreContext saved_context(context);
+
+    // Workaround for MSVC++ not supporting zero-sized arrays.
     wasm::own<wasm::Trap> trap = nullptr;
     if constexpr (sizeof...(args) > 0) {
       wasm::Val params[] = {makeVal(args)...};
@@ -599,6 +601,7 @@ void V8::getModuleFunctionImpl(std::string_view function_name,
       }
       trap = func->call(nullptr, nullptr);
     }
+
     if (trap) {
       fail(FailState::RuntimeError, getFailMessage(std::string(function_name), std::move(trap)));
       return;
@@ -634,6 +637,8 @@ void V8::getModuleFunctionImpl(std::string_view function_name,
     const bool log = cmpLogLevel(LogLevel::trace);
     SaveRestoreContext saved_context(context);
     wasm::Val results[1];
+
+    // Workaround for MSVC++ not supporting zero-sized arrays.
     wasm::own<wasm::Trap> trap = nullptr;
     if constexpr (sizeof...(args) > 0) {
       wasm::Val params[] = {makeVal(args)...};
@@ -648,6 +653,7 @@ void V8::getModuleFunctionImpl(std::string_view function_name,
       }
       trap = func->call(nullptr, results);
     }
+
     if (trap) {
       fail(FailState::RuntimeError, getFailMessage(std::string(function_name), std::move(trap)));
       return R{};

--- a/src/v8/v8.cc
+++ b/src/v8/v8.cc
@@ -585,9 +585,9 @@ void V8::getModuleFunctionImpl(std::string_view function_name,
   *function = [func, function_name, this](ContextBase *context, Args... args) -> void {
     const bool log = cmpLogLevel(LogLevel::trace);
     SaveRestoreContext saved_context(context);
+    wasm::own<wasm::Trap> trap = nullptr;
 
     // Workaround for MSVC++ not supporting zero-sized arrays.
-    wasm::own<wasm::Trap> trap = nullptr;
     if constexpr (sizeof...(args) > 0) {
       wasm::Val params[] = {makeVal(args)...};
       if (log) {
@@ -637,9 +637,9 @@ void V8::getModuleFunctionImpl(std::string_view function_name,
     const bool log = cmpLogLevel(LogLevel::trace);
     SaveRestoreContext saved_context(context);
     wasm::Val results[1];
+    wasm::own<wasm::Trap> trap = nullptr;
 
     // Workaround for MSVC++ not supporting zero-sized arrays.
-    wasm::own<wasm::Trap> trap = nullptr;
     if constexpr (sizeof...(args) > 0) {
       wasm::Val params[] = {makeVal(args)...};
       if (log) {

--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -594,9 +594,9 @@ void Wasmtime::getModuleFunctionImpl(std::string_view function_name,
     const bool log = cmpLogLevel(LogLevel::trace);
     SaveRestoreContext saved_context(context);
     wasm_val_vec_t results = WASM_EMPTY_VEC;
+    WasmTrapPtr trap;
 
     // Workaround for MSVC++ not supporting zero-sized arrays.
-    WasmTrapPtr trap;
     if constexpr (sizeof...(args) > 0) {
       wasm_val_t params_arr[] = {makeVal(args)...};
       wasm_val_vec_t params = WASM_ARRAY_VEC(params_arr);
@@ -656,9 +656,9 @@ void Wasmtime::getModuleFunctionImpl(std::string_view function_name,
     SaveRestoreContext saved_context(context);
     wasm_val_t results_arr[1];
     wasm_val_vec_t results = WASM_ARRAY_VEC(results_arr);
+    WasmTrapPtr trap;
 
     // Workaround for MSVC++ not supporting zero-sized arrays.
-    WasmTrapPtr trap;
     if constexpr (sizeof...(args) > 0) {
       wasm_val_t params_arr[] = {makeVal(args)...};
       wasm_val_vec_t params = WASM_ARRAY_VEC(params_arr);

--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -591,21 +591,28 @@ void Wasmtime::getModuleFunctionImpl(std::string_view function_name,
   }
 
   *function = [func, function_name, this](ContextBase *context, Args... args) -> void {
-    wasm_val_vec_t params;
+    const bool log = cmpLogLevel(LogLevel::trace);
+    SaveRestoreContext saved_context(context);
+    wasm_val_vec_t results = WASM_EMPTY_VEC;
+
+    // Workaround for MSVC++ not supporting zero-sized arrays.
+    WasmTrapPtr trap;
     if constexpr (sizeof...(args) > 0) {
       wasm_val_t params_arr[] = {makeVal(args)...};
-      params = WASM_ARRAY_VEC(params_arr);
+      wasm_val_vec_t params = WASM_ARRAY_VEC(params_arr);
+      if (log) {
+        integration()->trace("[host->vm] " + std::string(function_name) + "(" +
+                             printValues(&params) + ")");
+      }
+      trap.reset(wasm_func_call(func, &params, &results));
     } else {
-      params = WASM_EMPTY_VEC;
+      wasm_val_vec_t params = WASM_EMPTY_VEC;
+      if (log) {
+        integration()->trace("[host->vm] " + std::string(function_name) + "()");
+      }
+      trap.reset(wasm_func_call(func, &params, &results));
     }
-    wasm_val_vec_t results = WASM_EMPTY_VEC;
-    const bool log = cmpLogLevel(LogLevel::trace);
-    if (log) {
-      integration()->trace("[host->vm] " + std::string(function_name) + "(" + printValues(&params) +
-                           ")");
-    }
-    SaveRestoreContext saved_context(context);
-    WasmTrapPtr trap{wasm_func_call(func, &params, &results)};
+
     if (trap) {
       WasmByteVec error_message;
       wasm_trap_message(trap.get(), error_message.get());
@@ -645,22 +652,29 @@ void Wasmtime::getModuleFunctionImpl(std::string_view function_name,
   }
 
   *function = [func, function_name, this](ContextBase *context, Args... args) -> R {
-    wasm_val_vec_t params;
-    if constexpr (sizeof...(args) > 0) {
-      wasm_val_t params_arr[] = {makeVal(args)...};
-      params = WASM_ARRAY_VEC(params_arr);
-    } else {
-      params = WASM_EMPTY_VEC;
-    }
+    const bool log = cmpLogLevel(LogLevel::trace);
+    SaveRestoreContext saved_context(context);
     wasm_val_t results_arr[1];
     wasm_val_vec_t results = WASM_ARRAY_VEC(results_arr);
-    const bool log = cmpLogLevel(LogLevel::trace);
-    if (log) {
-      integration()->trace("[host->vm] " + std::string(function_name) + "(" + printValues(&params) +
-                           ")");
+
+    // Workaround for MSVC++ not supporting zero-sized arrays.
+    WasmTrapPtr trap;
+    if constexpr (sizeof...(args) > 0) {
+      wasm_val_t params_arr[] = {makeVal(args)...};
+      wasm_val_vec_t params = WASM_ARRAY_VEC(params_arr);
+      if (log) {
+        integration()->trace("[host->vm] " + std::string(function_name) + "(" +
+                             printValues(&params) + ")");
+      }
+      trap.reset(wasm_func_call(func, &params, &results));
+    } else {
+      wasm_val_vec_t params = WASM_EMPTY_VEC;
+      if (log) {
+        integration()->trace("[host->vm] " + std::string(function_name) + "()");
+      }
+      trap.reset(wasm_func_call(func, &params, &results));
     }
-    SaveRestoreContext saved_context(context);
-    WasmTrapPtr trap{wasm_func_call(func, &params, &results)};
+
     if (trap) {
       WasmByteVec error_message;
       wasm_trap_message(trap.get(), error_message.get());


### PR DESCRIPTION
Broken in proxy-wasm/proxy-wasm-cpp-host#217.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>