### PR TITLE
Add a nullptr check to prevent a memory exception in testing

### DIFF
--- a/include/proxy-wasm/wasm.h
+++ b/include/proxy-wasm/wasm.h
@@ -357,7 +357,7 @@ public:
                             std::shared_ptr<PluginBase> plugin)
       : plugin_(plugin), wasm_handle_(wasm_handle) {}
   ~PluginHandleBase() {
-    if (wasm_handle_) {
+    if (wasm_handle_ && wasm_handle_->wasm()) {
       wasm_handle_->wasm()->startShutdown(plugin_->key());
     }
   }

--- a/include/proxy-wasm/wasm.h
+++ b/include/proxy-wasm/wasm.h
@@ -357,7 +357,7 @@ public:
                             std::shared_ptr<PluginBase> plugin)
       : plugin_(plugin), wasm_handle_(wasm_handle) {}
   ~PluginHandleBase() {
-    if (wasm_handle_ && wasm_handle_->wasm()) {
+    if (wasm_handle_ && wasm_handle_->wasm() && plugin_) {
       wasm_handle_->wasm()->startShutdown(plugin_->key());
     }
   }


### PR DESCRIPTION
This PR simply adds a nullptr check to avoid a memory exception when "wasm_handle_" has nullptr "wasm".

I think that this may not happen in real use cases, but, during making new test cases to enhance the coverage in Envoy side, this was needed. 

In addition. null check for "plugin_" is also added.

Signed-off-by: Ingwon Song <igsong@google.com>