### PR TITLE
Add multi-engine build without WAVM.

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -135,7 +135,7 @@ jobs:
       run: >
         bazel build
         --config clang-tidy
-        --define engine=multi
+        --define engine=nowavm
         --copt=-DPROXY_WASM_VERIFY_WITH_ED25519_PUBKEY=\"$(xxd -p -c 256 test/test_data/signature_key1.pub | cut -b9-)\"
         //...
 

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -36,6 +36,11 @@ config_setting(
 )
 
 config_setting(
+    name = "multiengine_nowavm",
+    values = {"define": "engine=nowavm"},
+)
+
+config_setting(
     name = "requested_crypto_system",
     values = {"define": "crypto=system"},
 )

--- a/bazel/select.bzl
+++ b/bazel/select.bzl
@@ -16,6 +16,7 @@ def proxy_wasm_select_engine_null(xs):
     return select({
         "@proxy_wasm_cpp_host//bazel:engine_null": xs,
         "@proxy_wasm_cpp_host//bazel:multiengine": xs,
+        "@proxy_wasm_cpp_host//bazel:multiengine_nowavm": xs,
         "//conditions:default": [],
     })
 
@@ -23,6 +24,7 @@ def proxy_wasm_select_engine_v8(xs):
     return select({
         "@proxy_wasm_cpp_host//bazel:engine_v8": xs,
         "@proxy_wasm_cpp_host//bazel:multiengine": xs,
+        "@proxy_wasm_cpp_host//bazel:multiengine_nowavm": xs,
         "//conditions:default": [],
     })
 
@@ -30,6 +32,7 @@ def proxy_wasm_select_engine_wamr(xs):
     return select({
         "@proxy_wasm_cpp_host//bazel:engine_wamr": xs,
         "@proxy_wasm_cpp_host//bazel:multiengine": xs,
+        "@proxy_wasm_cpp_host//bazel:multiengine_nowavm": xs,
         "//conditions:default": [],
     })
 
@@ -37,6 +40,7 @@ def proxy_wasm_select_engine_wasmtime(xs, xp):
     return select({
         "@proxy_wasm_cpp_host//bazel:engine_wasmtime": xs,
         "@proxy_wasm_cpp_host//bazel:multiengine": xp,
+        "@proxy_wasm_cpp_host//bazel:multiengine_nowavm": xs,
         "//conditions:default": [],
     })
 
@@ -44,6 +48,7 @@ def proxy_wasm_select_engine_wasmedge(xs):
     return select({
         "@proxy_wasm_cpp_host//bazel:engine_wasmedge": xs,
         "@proxy_wasm_cpp_host//bazel:multiengine": xs,
+        "@proxy_wasm_cpp_host//bazel:multiengine_nowavm": xs,
         "//conditions:default": [],
     })
 


### PR DESCRIPTION
This should prevent clang-tidy from analyzing LLVM on the CI.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>