### PR TITLE
Add default visibility to Bazel's config_settings.

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,5 +1,7 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
+package(default_visibility = ["//visibility:public"])
+
 config_setting(
     name = "engine_null",
     values = {"define": "engine=null"},


### PR DESCRIPTION
In a future version of bazel visibility on config_settings will be enforced. This allows these to be used by anyone.

https://github.com/envoyproxy/envoy/issues/23390