### PR TITLE
wasmedge: update to v0.11.2.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,6 +187,12 @@ jobs:
           arch: x86_64
           action: test
           flags: --config=clang
+        - name: 'WasmEdge on macOS/x86_64'
+          engine: 'wasmedge'
+          repo: 'com_github_wasmedge_wasmedge'
+          os: macos-11
+          arch: x86_64
+          action: test
         - name: 'Wasmtime on Linux/x86_64'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'

--- a/BUILD
+++ b/BUILD
@@ -150,10 +150,15 @@ cc_library(
         "PROXY_WASM_HAS_RUNTIME_WASMEDGE",
         "PROXY_WASM_HOST_ENGINE_WASMEDGE",
     ],
-    linkopts = [
-        "-lrt",
-        "-ldl",
-    ],
+    linkopts = select({
+        "@platforms//os:macos": [
+            "-ldl",
+        ],
+        "//conditions:default": [
+            "-lrt",
+            "-ldl",
+        ],
+    }),
     deps = [
         ":wasm_vm_headers",
         "//external:wasmedge",

--- a/bazel/external/wasmedge.BUILD
+++ b/bazel/external/wasmedge.BUILD
@@ -20,5 +20,5 @@ cmake(
     },
     generate_args = ["-GNinja"],
     lib_source = ":srcs",
-    out_static_libs = ["libwasmedge_c.a"],
+    out_static_libs = ["libwasmedge.a"],
 )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -176,9 +176,9 @@ def proxy_wasm_cpp_host_repositories():
         http_archive,
         name = "com_github_wasmedge_wasmedge",
         build_file = "@proxy_wasm_cpp_host//bazel/external:wasmedge.BUILD",
-        sha256 = "4cff44e8c805ed4364d326ff1dd40e3aeb21ba1a11388372386eea1ccc7f93dd",
-        strip_prefix = "WasmEdge-proxy-wasm-0.10.0",
-        url = "https://github.com/WasmEdge/WasmEdge/archive/refs/tags/proxy-wasm/0.10.0.tar.gz",
+        sha256 = "65d95e5f83d25ab09fa9a29369f578838e8a519fb170704d0f5896187364429b",
+        strip_prefix = "WasmEdge-proxy-wasm-0.11.2",
+        url = "https://github.com/WasmEdge/WasmEdge/archive/refs/tags/proxy-wasm/0.11.2.tar.gz",
     )
 
     native.bind(

--- a/src/wasmedge/wasmedge.cc
+++ b/src/wasmedge/wasmedge.cc
@@ -417,7 +417,7 @@ void WasmEdge::registerHostFunctionImpl(std::string_view module_name,
   auto *func_type = newWasmEdgeFuncType<std::tuple<Args...>>();
   data->vm_ = this;
   data->raw_func_ = reinterpret_cast<void *>(function);
-  data->callback_ = [](void *data, WasmEdge_MemoryInstanceContext * /*MemCxt*/,
+  data->callback_ = [](void *data, const WasmEdge_CallingFrameContext * /*CallFrameCxt*/,
                        const WasmEdge_Value *Params,
                        WasmEdge_Value * /*Returns*/) -> WasmEdge_Result {
     auto *func_data = reinterpret_cast<HostFuncData *>(data);
@@ -464,7 +464,7 @@ void WasmEdge::registerHostFunctionImpl(std::string_view module_name,
   auto *func_type = newWasmEdgeFuncType<R, std::tuple<Args...>>();
   data->vm_ = this;
   data->raw_func_ = reinterpret_cast<void *>(function);
-  data->callback_ = [](void *data, WasmEdge_MemoryInstanceContext * /*MemCxt*/,
+  data->callback_ = [](void *data, const WasmEdge_CallingFrameContext * /*CallFrameCxt*/,
                        const WasmEdge_Value *Params, WasmEdge_Value *Returns) -> WasmEdge_Result {
     auto *func_data = reinterpret_cast<HostFuncData *>(data);
     const bool log = func_data->vm_->cmpLogLevel(LogLevel::trace);


### PR DESCRIPTION
* Update WasmEdge to 0.11.2.
* Support MacOS x86_64.