### PR TITLE
Bump v8 to version 11.2.34

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -126,10 +126,10 @@ def proxy_wasm_cpp_host_repositories():
     maybe(
         git_repository,
         name = "v8",
-        # 10.7.193.13
-        commit = "6c8b357a84847a479cd329478522feefc1c3195a",
+        # 11.2.34
+        commit = "fb6dd9c9d5034ca221e895b01072b0269f2611e7",
         remote = "https://chromium.googlesource.com/v8/v8",
-        shallow_since = "1664374400 +0000",
+        shallow_since = "1675228587 -0800",
         patches = ["@proxy_wasm_cpp_host//bazel/external:v8.patch"],
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
Hi .. @lizan @PiotrSikora Hi .. I'd like to bump v8 used here to a more recent version. Ultimately this is to support the version used in envoy. Two things concerning this:

(1) In envoy there is a patch file located here: [](https://github.com/envoyproxy/envoy/blob/main/bazel/v8.patch) which is beefer version of the one found here: [](https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/master/bazel/external/v8.patch) .. basically subsuming what is found in the v8.patch in this repository. So first, should these files be consistent? Second, how do I test that the patch applies OK here when building. I wasn't sure which target to build to test the new v8 but I choose this one this set of commands at the root:

```
bazel clean --expunge
bazel build  --worker_verbose --verbose_explanations=true --verbose_failures --sandbox_debug --explain=build.out.txt //:v8_lib

```
The build completed and clearly seem to bring in the new v8. However, when I sabotaged the v8.patch by adding garbage to it, the steps above still worked. Clearly the v8.patch file was not applied while building v8. 

- Also a related question .. does the build command above build the v8 library or the wee8 library (which I understand is target option when compiling v8)?

(2) The build files in envoy have pointers to a version of v8 found here:

https://github.com/envoyproxy/envoy/blob/9d9940b49f642fcf483ac8ff387ecb521dcf94fc/bazel/repository_locations.bzl#L1065-L1078

in repositories_locations.bzl point to the same version of v8 as listed here:

https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/0f5a0e798bcfbd3bf1e6b54359d7a004b009c584/bazel/repositories.bzl#L126-L135

So, setting aside that I don't understand why the envoy build needs to point to a different repository with the same code for v8 that is already brought in by proxy-wasm-cpp-host, based on some comments from @lizan about dependencies being flattened, I do assume these to sources need to be the same version of v8.  So I tried to do a wget on the location here:

 urls = ["https://storage.googleapis.com/envoyproxy-wee8/v8-{version}.tar.gz"],

substituting the version number (11.2.34) this patch is trying to bump to and the file was not found. Of course the old commit version (10.7.193.13) is found. How do I update this location with the version of v8 consistent to the one now pointed to in this patch?

So my primary questions are:
(1) How do I test that v8.patch is applied properly when just building proxy-wasm-cpp-host.
(2) Which v8.patch file is used by envoy (the one in the envoy repo or the one in this repo)
(3) Should these two v8.patch files be identical?
(4) How do I update https://storage.googleapis.com/ to include v8-11.2.34.tar.gz

I guess I have another question related to this patch. I'd  like to include a v8 patch file for proxy-wasm-cpp-host (or envoy) that is targeting build flags in v8 friendly to debugging and perf analysis. I assume that needs to be done with a patch file. How do I add another v8-perf.patch file that is only used when specified with some command line flag when building.






nearly identically but basically subsumes what is here in this repository: 

 