### PR TITLE
Bump v8 to version 11.0.226.13

### DIFF
--- a/bazel/external/v8.patch
+++ b/bazel/external/v8.patch
@@ -12,24 +12,131 @@ index 5fb10d3940..a19930d36e 100644
 -    default = "none",
 +    default = "False",
  )
- 
+
  # Default setting for v8_enable_pointer_compression.
 diff --git a/src/wasm/c-api.cc b/src/wasm/c-api.cc
 index ce3f569fd5..dc8a4c4f6a 100644
 --- a/src/wasm/c-api.cc
 +++ b/src/wasm/c-api.cc
 @@ -2238,6 +2238,8 @@ auto Instance::exports() const -> ownvec<Extern> {
- 
+
  }  // namespace wasm
- 
+
 +#if 0
 +
  // BEGIN FILE wasm-c.cc
- 
+
  extern "C" {
 @@ -3257,3 +3259,5 @@ wasm_instance_t* wasm_frame_instance(const wasm_frame_t* frame) {
  #undef WASM_DEFINE_SHARABLE_REF
- 
+
  }  // extern "C"
 +
 +#endif
+
+# Fix include paths in save_registers_acm.cc files. Current includes in these files are of the system
+# header types which do not work with the -iquote flag which bazel is using here when building
+diff --git a/src/heap/base/asm/arm/save_registers_asm.cc b/src/heap/base/asm/arm/save_registers_asm.cc
+index ace95036f2..39437289a2 100644
+--- a/src/heap/base/asm/arm/save_registers_asm.cc
++++ b/src/heap/base/asm/arm/save_registers_asm.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+
+-#include <src/heap/base/stack.h>
++#include "src/heap/base/stack.h"
+
+ // Save all callee-saved registers in the specified buffer.
+ // extern "C" void SaveCalleeSavedRegisters(intptr_t* buffer);
+diff --git a/src/heap/base/asm/arm64/save_registers_asm.cc b/src/heap/base/asm/arm64/save_registers_asm.cc
+index 5fe81d8e38..e6117f56f1 100644
+--- a/src/heap/base/asm/arm64/save_registers_asm.cc
++++ b/src/heap/base/asm/arm64/save_registers_asm.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+
+-#include <src/heap/base/stack.h>
++#include "src/heap/base/stack.h"
+
+ // Save all callee-saved registers in the specified buffer.
+ // extern "C" void SaveCalleeSavedRegisters(intptr_t* buffer);
+diff --git a/src/heap/base/asm/ia32/save_registers_asm.cc b/src/heap/base/asm/ia32/save_registers_asm.cc
+index 7c05247fef..9b37c3d60b 100644
+--- a/src/heap/base/asm/ia32/save_registers_asm.cc
++++ b/src/heap/base/asm/ia32/save_registers_asm.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+
+-#include <src/heap/base/stack.h>
++#include "src/heap/base/stack.h"
+
+ // Save all callee-saved registers in the specified buffer.
+ // extern "C" void SaveCalleeSavedRegisters(intptr_t* buffer);
+diff --git a/src/heap/base/asm/loong64/save_registers_asm.cc b/src/heap/base/asm/loong64/save_registers_asm.cc
+index d5b110d7ee..8aa7eb250d 100644
+--- a/src/heap/base/asm/loong64/save_registers_asm.cc
++++ b/src/heap/base/asm/loong64/save_registers_asm.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+
+-#include <src/heap/base/stack.h>
++#include "src/heap/base/stack.h"
+
+ // Save all callee-saved registers in the specified buffer.
+ // extern "C" void SaveCalleeSavedRegisters(intptr_t* buffer);
+diff --git a/src/heap/base/asm/mips64/save_registers_asm.cc b/src/heap/base/asm/mips64/save_registers_asm.cc
+index 95bcc319ae..7ebd3ba572 100644
+--- a/src/heap/base/asm/mips64/save_registers_asm.cc
++++ b/src/heap/base/asm/mips64/save_registers_asm.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+
+-#include <src/heap/base/stack.h>
++#include "src/heap/base/stack.h"
+
+ // Save all callee-saved registers in the specified buffer.
+ // extern "C" void SaveCalleeSavedRegisters(intptr_t* buffer);
+diff --git a/src/heap/base/asm/ppc/save_registers_asm.cc b/src/heap/base/asm/ppc/save_registers_asm.cc
+index 9e8102a66f..8997ac13a0 100644
+--- a/src/heap/base/asm/ppc/save_registers_asm.cc
++++ b/src/heap/base/asm/ppc/save_registers_asm.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+
+-#include <src/heap/base/stack.h>
++#include "src/heap/base/stack.h"
+
+ // Save all callee-saved registers in the specified buffer.
+ // extern "C" void SaveCalleeSavedRegisters(intptr_t* buffer);
+diff --git a/src/heap/base/asm/s390/save_registers_asm.cc b/src/heap/base/asm/s390/save_registers_asm.cc
+index be92cc2382..ac78fdac95 100644
+--- a/src/heap/base/asm/s390/save_registers_asm.cc
++++ b/src/heap/base/asm/s390/save_registers_asm.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+
+-#include <src/heap/base/stack.h>
++#include "src/heap/base/stack.h"
+
+ // Save all callee-saved registers in the specified buffer.
+ // extern "C" void SaveCalleeSavedRegisters(intptr_t* buffer);
+diff --git a/src/heap/base/asm/x64/save_registers_asm.cc b/src/heap/base/asm/x64/save_registers_asm.cc
+index 855a654de9..49996312e0 100644
+--- a/src/heap/base/asm/x64/save_registers_asm.cc
++++ b/src/heap/base/asm/x64/save_registers_asm.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+
+-#include <src/heap/base/stack.h>
++#include "src/heap/base/stack.h"
+
+ // Save all callee-saved registers in the specified buffer.
+ // extern "C" void SaveCalleeSavedRegisters(intptr_t* buffer);

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -126,10 +126,10 @@ def proxy_wasm_cpp_host_repositories():
     maybe(
         git_repository,
         name = "v8",
-        # 10.7.193.13
-        commit = "6c8b357a84847a479cd329478522feefc1c3195a",
+        # 11.0.226.13
+        commit = "dc183b6f8195ebf0c4baa55fd14eddad48894258",
         remote = "https://chromium.googlesource.com/v8/v8",
-        shallow_since = "1664374400 +0000",
+        shallow_since = "1675097135 -0800",
         patches = ["@proxy_wasm_cpp_host//bazel/external:v8.patch"],
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
Updates to v8 to version 11.0.226.13
Note, the BTEC is unchanged so is not updated in repositories.bzl

Note this is a follow up for this draft PR https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/327
Had to rename branch since we are pushing a different version of v8 here compared to the previous iteration.

This is not quite ready as would like to understand the nature of callee-saved register bug mentioned here http://crrev.com/c/4171639 before updating to this version of v8.