### PR TITLE
rustc_flags linker flag no longer needed for s390x

### DIFF
--- a/bazel/wasm.bzl
+++ b/bazel/wasm.bzl
@@ -77,7 +77,7 @@ wasi_rust_binary_rule = rule(
     attrs = _wasm_attrs(wasi_rust_transition),
 )
 
-def wasm_rust_binary(name, tags = [], wasi = False, signing_key = [], rustc_flags = [], **kwargs):
+def wasm_rust_binary(name, tags = [], wasi = False, signing_key = [], **kwargs):
     wasm_name = "_wasm_" + name.replace(".", "_")
     kwargs.setdefault("visibility", ["//visibility:public"])
 
@@ -87,11 +87,6 @@ def wasm_rust_binary(name, tags = [], wasi = False, signing_key = [], rustc_flag
         crate_type = "cdylib",
         out_binary = True,
         tags = ["manual"],
-        # Rust doesn't distribute rust-lld for Linux/s390x.
-        rustc_flags = rustc_flags + select({
-            "//bazel:linux_s390x": ["-C", "linker=/usr/bin/lld"],
-            "//conditions:default": [],
-        }),
         **kwargs
     )
 


### PR DESCRIPTION
Starting with v1.61 rust s390x package contains rust-lld