### PR TITLE
Update rules_rust to v0.22.0 (with Rust v1.69.0).

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -74,10 +74,10 @@ def proxy_wasm_cpp_host_repositories():
     maybe(
         http_archive,
         name = "rules_rust",
-        sha256 = "c8a84a01bff4be4c7a8beefbc12e713ff296fed2110c30572a44205856594cfc",
-        strip_prefix = "rules_rust-0.19.0",
+        sha256 = "88a6911bf60c44710407cc718668ce79a4a339e1310b47f306aa0f1beadc6895",
+        strip_prefix = "rules_rust-0.22.0",
         # NOTE: Update Rust version in bazel/dependencies.bzl.
-        url = "https://github.com/bazelbuild/rules_rust/archive/0.19.0.tar.gz",
+        url = "https://github.com/bazelbuild/rules_rust/archive/0.22.0.tar.gz",
         patches = ["@proxy_wasm_cpp_host//bazel/external:rules_rust.patch"],
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
The current wasmtime version has a CVE version showing https://github.com/envoyproxy/envoy/issues/27422

Historically updating wasmtime here has required updating rules_rust so i have broken out the update here