### PR TITLE
Auto-cancel old GitHub Actions workflows.

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -32,6 +32,7 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
+
   group: ${{ github.head_ref || github.run_id }}-${{ github.workflow }}
   cancel-in-progress: true
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -31,6 +31,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
 
   addlicense:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
 
   test_data:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
+
   group: ${{ github.head_ref || github.run_id }}-${{ github.workflow }}
   cancel-in-progress: true
 


### PR DESCRIPTION
Currently workflows in this repo (which take a huge amount of time) continue when new commits are pushed to PRs

This will autocancel existing runs for PRs