### PR TITLE
Fix memory leak in thread-local VM & plugin caches

### DIFF
--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -60,7 +60,8 @@ void cacheLocalWasm(const std::string &key, const std::shared_ptr<WasmHandleBase
   local_wasms_keys.emplace(key);
 }
 
-void cacheLocalPlugin(const std::string &key, const std::shared_ptr<PluginHandleBase> &plugin_handle) {
+void cacheLocalPlugin(const std::string &key,
+                      const std::shared_ptr<PluginHandleBase> &plugin_handle) {
   local_plugins[key] = plugin_handle;
   local_plugins_keys.emplace(key);
 }

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -569,15 +569,14 @@ std::shared_ptr<WasmHandleBase> createWasm(const std::string &vm_key, const std:
 
 std::shared_ptr<WasmHandleBase> getThreadLocalWasm(std::string_view vm_key) {
   auto it = local_wasms.find(std::string(vm_key));
-  if (it == local_wasms.end()) {
-    removeStaleLocalCacheEntries(local_wasms, local_wasms_keys);
-    return nullptr;
+  if (it != local_wasms.end()) {
+    auto wasm = it->second.lock();
+    if (wasm) {
+      return wasm;
+    }
   }
-  auto wasm = it->second.lock();
-  if (!wasm) {
-    local_wasms.erase(std::string(vm_key));
-  }
-  return wasm;
+  removeStaleLocalCacheEntries(local_wasms, local_wasms_keys);
+  return nullptr;
 }
 
 static std::shared_ptr<WasmHandleBase>

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -47,7 +47,7 @@ thread_local std::unordered_map<std::string, std::weak_ptr<PluginHandleBase>> lo
 // Plugin key queue to track stale entries in `local_plugins`.
 thread_local std::queue<std::string> local_plugins_keys;
 
-// Check no more than `max_local_cache_gc_chunk_size` cache entries at a time during stale entries
+// Check no more than `MAX_LOCAL_CACHE_GC_CHUNK_SIZE` cache entries at a time during stale entries
 // cleanup.
 const size_t MAX_LOCAL_CACHE_GC_CHUNK_SIZE = 64;
 

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -55,12 +55,12 @@ const size_t max_local_cache_gc_chunk_size = 64;
 std::mutex base_wasms_mutex;
 std::unordered_map<std::string, std::weak_ptr<WasmHandleBase>> *base_wasms = nullptr;
 
-void cacheLocalWasm(const std::string &key, std::shared_ptr<WasmHandleBase> wasm_handle) {
+void cacheLocalWasm(const std::string &key, const std::shared_ptr<WasmHandleBase> &wasm_handle) {
   local_wasms[key] = wasm_handle;
   local_wasms_keys.emplace(key);
 }
 
-void cacheLocalPlugin(const std::string &key, std::shared_ptr<PluginHandleBase> plugin_handle) {
+void cacheLocalPlugin(const std::string &key, const std::shared_ptr<PluginHandleBase> &plugin_handle) {
   local_plugins[key] = plugin_handle;
   local_plugins_keys.emplace(key);
 }

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -574,6 +574,7 @@ std::shared_ptr<WasmHandleBase> getThreadLocalWasm(std::string_view vm_key) {
     if (wasm) {
       return wasm;
     }
+    local_wasms.erase(it);
   }
   removeStaleLocalCacheEntries(local_wasms, local_wasms_keys);
   return nullptr;
@@ -590,6 +591,7 @@ getOrCreateThreadLocalWasm(const std::shared_ptr<WasmHandleBase> &base_handle,
     if (wasm_handle) {
       return wasm_handle;
     }
+    local_wasms.erase(it);
   }
   removeStaleLocalCacheEntries(local_wasms, local_wasms_keys);
   // Create and initialize new thread-local WasmVM.
@@ -626,6 +628,7 @@ std::shared_ptr<PluginHandleBase> getOrCreateThreadLocalPlugin(
     if (plugin_handle) {
       return plugin_handle;
     }
+    local_plugins.erase(it);
   }
   removeStaleLocalCacheEntries(local_plugins, local_plugins_keys);
   // Get thread-local WasmVM.

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -49,7 +49,7 @@ thread_local std::queue<std::string> local_plugins_keys;
 
 // Check no more than `max_local_cache_gc_chunk_size` cache entries at a time during stale entries
 // cleanup.
-const size_t max_local_cache_gc_chunk_size = 64;
+const size_t MAX_LOCAL_CACHE_GC_CHUNK_SIZE = 64;
 
 // Map from Wasm Key to the base Wasm instance, using a pointer to avoid the initialization fiasco.
 std::mutex base_wasms_mutex;
@@ -69,11 +69,7 @@ void cacheLocalPlugin(const std::string &key,
 template <class T>
 void removeStaleLocalCacheEntries(std::unordered_map<std::string, std::weak_ptr<T>> &cache,
                                   std::queue<std::string> &keys) {
-  auto num_keys_to_check = max_local_cache_gc_chunk_size;
-  if (num_keys_to_check > keys.size()) {
-    num_keys_to_check = keys.size();
-  }
-
+  auto num_keys_to_check = std::min(MAX_LOCAL_CACHE_GC_CHUNK_SIZE, keys.size());
   for (size_t i = 0; i < num_keys_to_check; i++) {
     std::string key(keys.front());
     keys.pop();


### PR DESCRIPTION
Since VM and plugin thread-local cache keys include volatile parts (namely VM configuration, code and plugin configuration), their reconfiguration/update (e.g. with Envoy ADS protocol) might lead to memory leak by leaving those thread-local map stale keys behind. The current cleanup method is insufficient, as it accounts only for cache hit case.

Also, plugin configuration is placed into cache key as is (by contrast with SHA256 hash for VM keys), which causes noticeable memory consumption when configuration is large.