### PR TITLE
Remove @mathetake from CODEOWNERS.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @PiotrSikora @mathetake
+* @PiotrSikora


### PR DESCRIPTION
To clarify my position, this PR removes me from CODEOWNERS. 
I must admit this should've happened much earlier. Sorry about that.