### PR TITLE
fix a few missing includes and ::proxy_wasm namespace pollution with std {}

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -38,6 +38,7 @@ cc_library(
     name = "wasm_vm_headers",
     hdrs = [
         "include/proxy-wasm/limits.h",
+        "include/proxy-wasm/sdk.h",
         "include/proxy-wasm/wasm_vm.h",
         "include/proxy-wasm/word.h",
     ],

--- a/include/proxy-wasm/context.h
+++ b/include/proxy-wasm/context.h
@@ -26,12 +26,10 @@
 #include <string_view>
 #include <vector>
 
+#include "include/proxy-wasm/sdk.h"
 #include "include/proxy-wasm/context_interface.h"
 
 namespace proxy_wasm {
-
-#include "proxy_wasm_common.h"
-#include "proxy_wasm_enums.h"
 
 class PluginHandleBase;
 class WasmBase;

--- a/include/proxy-wasm/context_interface.h
+++ b/include/proxy-wasm/context_interface.h
@@ -25,10 +25,9 @@
 #include <memory>
 #include <vector>
 
-namespace proxy_wasm {
+#include "include/proxy-wasm/sdk.h"
 
-#include "proxy_wasm_common.h"
-#include "proxy_wasm_enums.h"
+namespace proxy_wasm {
 
 using Pairs = std::vector<std::pair<std::string_view, std::string_view>>;
 using PairsWithStringValues = std::vector<std::pair<std::string_view, std::string>>;

--- a/include/proxy-wasm/pairs_util.h
+++ b/include/proxy-wasm/pairs_util.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/include/proxy-wasm/sdk.h
+++ b/include/proxy-wasm/sdk.h
@@ -1,0 +1,54 @@
+// Copyright 2016-2019 Envoy Project Authors
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <cstdint>
+
+namespace proxy_wasm {
+
+namespace internal {
+
+// isolate those includes to prevent ::proxy_wasm namespace pollution with std
+// namespace definitions.
+namespace proxy_wasm {
+
+#include "proxy_wasm_common.h"
+#include "proxy_wasm_enums.h"
+
+} // namespace proxy_wasm
+
+} // namespace internal
+
+// proxy_wasm_common.h
+using WasmResult = internal::proxy_wasm::WasmResult;
+using WasmHeaderMapType = internal::proxy_wasm::WasmHeaderMapType;
+using WasmBufferType = internal::proxy_wasm::WasmBufferType;
+using WasmBufferFlags = internal::proxy_wasm::WasmBufferFlags;
+using WasmStreamType = internal::proxy_wasm::WasmStreamType;
+
+// proxy_wasm_enums.h
+using LogLevel = internal::proxy_wasm::LogLevel;
+using FilterStatus = internal::proxy_wasm::FilterStatus;
+using FilterHeadersStatus = internal::proxy_wasm::FilterHeadersStatus;
+using FilterMetadataStatus = internal::proxy_wasm::FilterMetadataStatus;
+using FilterTrailersStatus = internal::proxy_wasm::FilterTrailersStatus;
+using FilterDataStatus = internal::proxy_wasm::FilterDataStatus;
+using GrpcStatus = internal::proxy_wasm::GrpcStatus;
+using MetricType = internal::proxy_wasm::MetricType;
+using CloseType = internal::proxy_wasm::CloseType;
+
+} // namespace proxy_wasm

--- a/include/proxy-wasm/sdk.h
+++ b/include/proxy-wasm/sdk.h
@@ -24,31 +24,27 @@ namespace internal {
 
 // isolate those includes to prevent ::proxy_wasm namespace pollution with std
 // namespace definitions.
-namespace proxy_wasm {
-
 #include "proxy_wasm_common.h"
 #include "proxy_wasm_enums.h"
-
-} // namespace proxy_wasm
 
 } // namespace internal
 
 // proxy_wasm_common.h
-using WasmResult = internal::proxy_wasm::WasmResult;
-using WasmHeaderMapType = internal::proxy_wasm::WasmHeaderMapType;
-using WasmBufferType = internal::proxy_wasm::WasmBufferType;
-using WasmBufferFlags = internal::proxy_wasm::WasmBufferFlags;
-using WasmStreamType = internal::proxy_wasm::WasmStreamType;
+using WasmResult = internal::WasmResult;
+using WasmHeaderMapType = internal::WasmHeaderMapType;
+using WasmBufferType = internal::WasmBufferType;
+using WasmBufferFlags = internal::WasmBufferFlags;
+using WasmStreamType = internal::WasmStreamType;
 
 // proxy_wasm_enums.h
-using LogLevel = internal::proxy_wasm::LogLevel;
-using FilterStatus = internal::proxy_wasm::FilterStatus;
-using FilterHeadersStatus = internal::proxy_wasm::FilterHeadersStatus;
-using FilterMetadataStatus = internal::proxy_wasm::FilterMetadataStatus;
-using FilterTrailersStatus = internal::proxy_wasm::FilterTrailersStatus;
-using FilterDataStatus = internal::proxy_wasm::FilterDataStatus;
-using GrpcStatus = internal::proxy_wasm::GrpcStatus;
-using MetricType = internal::proxy_wasm::MetricType;
-using CloseType = internal::proxy_wasm::CloseType;
+using LogLevel = internal::LogLevel;
+using FilterStatus = internal::FilterStatus;
+using FilterHeadersStatus = internal::FilterHeadersStatus;
+using FilterMetadataStatus = internal::FilterMetadataStatus;
+using FilterTrailersStatus = internal::FilterTrailersStatus;
+using FilterDataStatus = internal::FilterDataStatus;
+using GrpcStatus = internal::GrpcStatus;
+using MetricType = internal::MetricType;
+using CloseType = internal::CloseType;
 
 } // namespace proxy_wasm

--- a/include/proxy-wasm/vm_id_handle.h
+++ b/include/proxy-wasm/vm_id_handle.h
@@ -15,8 +15,10 @@
 #pragma once
 
 #include <functional>
-#include <mutex>
 #include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
 #include <unordered_map>
 
 namespace proxy_wasm {

--- a/include/proxy-wasm/wasm.h
+++ b/include/proxy-wasm/wasm.h
@@ -24,14 +24,13 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "include/proxy-wasm/sdk.h"
 #include "include/proxy-wasm/context.h"
 #include "include/proxy-wasm/exports.h"
 #include "include/proxy-wasm/wasm_vm.h"
 #include "include/proxy-wasm/vm_id_handle.h"
 
 namespace proxy_wasm {
-
-#include "proxy_wasm_common.h"
 
 class ContextBase;
 class WasmHandleBase;

--- a/include/proxy-wasm/wasm_api_impl.h
+++ b/include/proxy-wasm/wasm_api_impl.h
@@ -30,14 +30,12 @@
 #include <utility>
 #include <vector>
 
+#include "include/proxy-wasm/sdk.h"
 #include "include/proxy-wasm/exports.h"
 #include "include/proxy-wasm/word.h"
 
 namespace proxy_wasm {
 namespace null_plugin {
-
-#include "proxy_wasm_enums.h"
-#include "proxy_wasm_common.h"
 
 #define WS(_x) Word(static_cast<uint64_t>(_x))
 #define WR(_x) Word(reinterpret_cast<uint64_t>(_x))

--- a/include/proxy-wasm/wasm_vm.h
+++ b/include/proxy-wasm/wasm_vm.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/include/proxy-wasm/wasm_vm.h
+++ b/include/proxy-wasm/wasm_vm.h
@@ -24,11 +24,10 @@
 #include <unordered_set>
 #include <vector>
 
+#include "include/proxy-wasm/sdk.h"
 #include "include/proxy-wasm/word.h"
 
 namespace proxy_wasm {
-
-#include "proxy_wasm_enums.h"
 
 class ContextBase;
 

--- a/include/proxy-wasm/word.h
+++ b/include/proxy-wasm/word.h
@@ -17,9 +17,9 @@
 
 #include <iostream>
 
-namespace proxy_wasm {
+#include "include/proxy-wasm/sdk.h"
 
-#include "proxy_wasm_common.h"
+namespace proxy_wasm {
 
 // Use byteswap functions only when compiling for big-endian platforms.
 #if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                                    \

--- a/test/fuzz/pairs_util_fuzzer.cc
+++ b/test/fuzz/pairs_util_fuzzer.cc
@@ -14,6 +14,7 @@
 
 #include "include/proxy-wasm/pairs_util.h"
 
+#include <cstdint>
 #include <cstring>
 
 namespace proxy_wasm {


### PR DESCRIPTION
fixes https://github.com/proxy-wasm/proxy-wasm-cpp-host/issues/364

- include: add missing dependencies 
- fix: proxy_wasm namespace polution with std defs 
- include: add missing includes to pairs_util and the test 

```
In file included from external/proxy_wasm_cpp_host/src/null/null.cc:17:
In file included from external/proxy_wasm_cpp_host/include/proxy-wasm/null_vm.h:22:
In file included from external/proxy_wasm_cpp_host/include/proxy-wasm/null_vm_plugin.h:18:
In file included from external/proxy_wasm_cpp_host/include/proxy-wasm/wasm_vm.h:26:
In file included from external/proxy_wasm_cpp_host/include/proxy-wasm/word.h:22:
external/proxy_wasm_cpp_sdk/proxy_wasm_common.h:59:8: error: no type named 'string' in namespace 'proxy_wasm::std'; did you mean '::std::string'?
inline std::string toString(WasmResult r) {
       ^~~~~~~~~~~
       ::std::string
```

reproduces:

    $ bazel build --config=clang --verbose_failures null_lib

Arch Linux, clang version 15.0.7, gcc version 13.2.1 20230801 (GCC)