### PR TITLE
Update ubuntu runner image to ubuntu-22.04

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,10 +3,16 @@ build --action_env=CC
 build --action_env=CXX
 build --action_env=PATH
 
-# Use Clang compiler.
+# Use Clang compiler with libc++.
 build:clang --action_env=BAZEL_COMPILER=clang
 build:clang --action_env=CC=clang
 build:clang --action_env=CXX=clang++
+build:clang --action_env=CXXFLAGS=-stdlib=libc++
+build:clang --action_env=LDFLAGS=-stdlib=libc++
+build:clang --action_env=BAZEL_CXXOPTS=-stdlib=libc++
+build:clang --action_env=BAZEL_LINKLIBS=-l%:libc++.a:-l%:libc++abi.a
+build:clang --action_env=BAZEL_LINKOPTS=-lm:-pthread
+build:clang --define force_libcpp=enabled
 
 # Common flags for Clang sanitizers.
 build:clang-xsan --config=clang

--- a/.bazelrc
+++ b/.bazelrc
@@ -12,7 +12,6 @@ build:clang --action_env=LDFLAGS=-stdlib=libc++
 build:clang --action_env=BAZEL_CXXOPTS=-stdlib=libc++
 build:clang --action_env=BAZEL_LINKLIBS=-l%:libc++.a:-l%:libc++abi.a
 build:clang --action_env=BAZEL_LINKOPTS=-lm:-pthread
-build:clang --define force_libcpp=enabled
 
 # Common flags for Clang sanitizers.
 build:clang-xsan --config=clang

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -41,7 +41,7 @@ jobs:
   addlicense:
     name: verify licenses
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2
@@ -61,7 +61,7 @@ jobs:
   buildifier:
     name: check format with buildifier
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2
@@ -105,7 +105,7 @@ jobs:
   clang_format:
     name: check format with clang-format
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2
@@ -121,7 +121,7 @@ jobs:
   clang_tidy:
     name: check format with clang-tidy
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
           flags: --config=clang-tsan
         - name: 'NullVM on Windows/x86_64'
           engine: 'null'
-          os: windows-2022
+          os: windows-2019
           arch: x86_64
           action: test
           targets: -//test/fuzz/...
@@ -176,7 +176,7 @@ jobs:
         - name: 'V8 on macOS/x86_64'
           engine: 'v8'
           repo: 'v8'
-          os: macos-12
+          os: macos-11
           arch: x86_64
           action: test
           cache: true
@@ -190,7 +190,7 @@ jobs:
         - name: 'WAMR interp on macOS/x86_64'
           engine: 'wamr-interp'
           repo: 'com_github_bytecodealliance_wasm_micro_runtime'
-          os: macos-12
+          os: macos-11
           arch: x86_64
           action: test
         - name: 'WAMR jit on Linux/x86_64'
@@ -205,7 +205,7 @@ jobs:
         - name: 'WAMR jit on macOS/x86_64'
           engine: 'wamr-jit'
           repo: 'com_github_bytecodealliance_wasm_micro_runtime'
-          os: macos-12
+          os: macos-11
           arch: x86_64
           action: test
           cache: true
@@ -219,7 +219,7 @@ jobs:
         - name: 'WasmEdge on macOS/x86_64'
           engine: 'wasmedge'
           repo: 'com_github_wasmedge_wasmedge'
-          os: macos-12
+          os: macos-11
           arch: x86_64
           action: test
         - name: 'Wasmtime on Linux/x86_64'
@@ -256,13 +256,13 @@ jobs:
         - name: 'Wasmtime on macOS/x86_64'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'
-          os: macos-12
+          os: macos-11
           arch: x86_64
           action: test
         - name: 'Wasmtime on Windows/x86_64'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'
-          os: windows-2022
+          os: windows-2019
           arch: x86_64
           action: test
           targets: -//test/fuzz/...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
   test_data:
     name: build test data
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2
@@ -109,32 +109,32 @@ jobs:
         include:
         - name: 'NullVM on Linux/x86_64'
           engine: 'null'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           action: test
           flags: --config=gcc
         - name: 'NullVM on Linux/x86_64 with ASan'
           engine: 'null'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           action: test
           flags: --config=clang-asan-strict --define=crypto=system
         - name: 'NullVM on Linux/x86_64 with TSan'
           engine: 'null'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           action: test
           flags: --config=clang-tsan
         - name: 'NullVM on Windows/x86_64'
           engine: 'null'
-          os: windows-2019
+          os: windows-2022
           arch: x86_64
           action: test
           targets: -//test/fuzz/...
         - name: 'V8 on Linux/x86_64'
           engine: 'v8'
           repo: 'v8'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           action: test
           flags: --config=clang --define=crypto=system
@@ -142,7 +142,7 @@ jobs:
         - name: 'V8 on Linux/x86_64 with ASan'
           engine: 'v8'
           repo: 'v8'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           action: test
           flags: --config=clang-asan
@@ -150,7 +150,7 @@ jobs:
         - name: 'V8 on Linux/x86_64 with TSan'
           engine: 'v8'
           repo: 'v8'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           action: test
           flags: --config=clang-tsan
@@ -158,7 +158,7 @@ jobs:
         - name: 'V8 on Linux/x86_64 with GCC'
           engine: 'v8'
           repo: 'v8'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           action: test
           flags: --config=gcc
@@ -166,7 +166,7 @@ jobs:
         - name: 'V8 on Linux/aarch64'
           engine: 'v8'
           repo: 'v8'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: aarch64
           action: test
           targets: -//test/fuzz/...
@@ -176,27 +176,27 @@ jobs:
         - name: 'V8 on macOS/x86_64'
           engine: 'v8'
           repo: 'v8'
-          os: macos-11
+          os: macos-12
           arch: x86_64
           action: test
           cache: true
         - name: 'WAMR interp on Linux/x86_64'
           engine: 'wamr-interp'
           repo: 'com_github_bytecodealliance_wasm_micro_runtime'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           action: test
           flags: --config=clang
         - name: 'WAMR interp on macOS/x86_64'
           engine: 'wamr-interp'
           repo: 'com_github_bytecodealliance_wasm_micro_runtime'
-          os: macos-11
+          os: macos-12
           arch: x86_64
           action: test
         - name: 'WAMR jit on Linux/x86_64'
           engine: 'wamr-jit'
           repo: 'com_github_bytecodealliance_wasm_micro_runtime'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           action: test
           flags: --config=clang
@@ -205,41 +205,41 @@ jobs:
         - name: 'WAMR jit on macOS/x86_64'
           engine: 'wamr-jit'
           repo: 'com_github_bytecodealliance_wasm_micro_runtime'
-          os: macos-11
+          os: macos-12
           arch: x86_64
           action: test
           cache: true
         - name: 'WasmEdge on Linux/x86_64'
           engine: 'wasmedge'
           repo: 'com_github_wasmedge_wasmedge'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           action: test
           flags: --config=clang
         - name: 'WasmEdge on macOS/x86_64'
           engine: 'wasmedge'
           repo: 'com_github_wasmedge_wasmedge'
-          os: macos-11
+          os: macos-12
           arch: x86_64
           action: test
         - name: 'Wasmtime on Linux/x86_64'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           action: test
           flags: --config=clang -c opt
         - name: 'Wasmtime on Linux/x86_64 with ASan'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           action: test
           flags: --config=clang-asan-strict --define=crypto=system
         - name: 'Wasmtime on Linux/aarch64'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: aarch64
           action: build
           flags: --config=zig-cc-linux-aarch64
@@ -247,7 +247,7 @@ jobs:
         - name: 'Wasmtime on Linux/s390x'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: s390x
           action: test
           flags: --config=clang --test_timeout=1800
@@ -256,20 +256,20 @@ jobs:
         - name: 'Wasmtime on macOS/x86_64'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'
-          os: macos-11
+          os: macos-12
           arch: x86_64
           action: test
         - name: 'Wasmtime on Windows/x86_64'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'
-          os: windows-2019
+          os: windows-2022
           arch: x86_64
           action: test
           targets: -//test/fuzz/...
         - name: 'WAVM on Linux/x86_64'
           engine: 'wavm'
           repo: 'com_github_wavm_wavm'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           action: test
           flags: --config=clang


### PR DESCRIPTION
Update ubuntu github runner to the same image used by Envoy:

ubuntu-20.04 -> ubuntu-22.04

Updates to windows and macos runner images will be in separate PRs, since they introduce build failures.

List of available images [here](https://github.com/actions/runner-images/tree/main).

Partially addresses #372 