### PR TITLE
Bump v8 version to fix llvm-14 build issues

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -126,10 +126,10 @@ def proxy_wasm_cpp_host_repositories():
     maybe(
         git_repository,
         name = "v8",
-        # 10.7.193.13
-        commit = "6c8b357a84847a479cd329478522feefc1c3195a",
+        # 11.4.183.33 from https://chromium.googlesource.com/v8/v8.git/+/branch-heads/11.4
+        commit = "d47acda203d55ed013ddf55600cf81549e12411d",
         remote = "https://chromium.googlesource.com/v8/v8",
-        shallow_since = "1664374400 +0000",
+        shallow_since = "1696364430 +0000",
         patches = ["@proxy_wasm_cpp_host//bazel/external:v8.patch"],
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
```
$ bazelisk build //test:wasm_vm_test --define engine=v8 --config=clang
...
In file included from external/v8/src/base/vlq-base64.cc:8:
external/v8/src/base/logging.h:154:26: error: use of undeclared identifier 'uint16_t'
                         uint16_t> >;
                         ^
external/v8/src/base/logging.h:155:22: error: unknown type name 'int_t'
  return static_cast<int_t>(static_cast<underlying_t>(val));
                     ^
```