### PR TITLE
DynVm Implementation: Dynamically loaded native modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
           flags: --config=gcc
         - name: 'DynVM on Linux/x86_64'
           engine: 'dyn'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           arch: x86_64
           action: test
           flags: --config=gcc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,12 @@ jobs:
           arch: x86_64
           action: test
           flags: --config=gcc
+        - name: 'DynVM on Linux/x86_64'
+          engine: 'dyn'
+          os: ubuntu-20.04
+          arch: x86_64
+          action: test
+          flags: --config=gcc
         - name: 'NullVM on Linux/x86_64 with ASan'
           engine: 'null'
           os: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /bazel-*
+.vscode

--- a/BUILD
+++ b/BUILD
@@ -132,6 +132,7 @@ cc_library(
         "src/dyn/dyn_vm_plugin.cc",
     ],
     hdrs = [
+        "include/proxy-wasm/dyn.h",
         "include/proxy-wasm/dyn_vm.h",
         "include/proxy-wasm/dyn_vm_plugin.h",
         "include/proxy-wasm/wasm_api_impl.h",

--- a/BUILD
+++ b/BUILD
@@ -14,6 +14,7 @@
 
 load(
     "@proxy_wasm_cpp_host//bazel:select.bzl",
+    "proxy_wasm_select_engine_dyn",
     "proxy_wasm_select_engine_null",
     "proxy_wasm_select_engine_v8",
     "proxy_wasm_select_engine_wamr",
@@ -120,6 +121,31 @@ cc_library(
         "@com_google_protobuf//:protobuf_lite",
         "@proxy_wasm_cpp_sdk//:api_lib",
     ],
+)
+
+cc_library(
+    name = "dyn_lib",
+    srcs = [
+        "src/dyn/dyn.cc",
+        "src/dyn/dyn_ffi.cc",
+        "src/dyn/dyn_vm.cc",
+        "src/dyn/dyn_vm_plugin.cc",
+    ],
+    hdrs = [
+        "include/proxy-wasm/dyn_vm.h",
+        "include/proxy-wasm/dyn_vm_plugin.h",
+        "include/proxy-wasm/wasm_api_impl.h",
+    ],
+    defines = [
+        "PROXY_WASM_HAS_RUNTIME_DYN",
+        "PROXY_WASM_HOST_ENGINE_DYN",
+    ],
+    deps = [
+        ":headers",
+        "@com_google_protobuf//:protobuf_lite",
+        "@proxy_wasm_cpp_sdk//:api_lib",
+    ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -315,6 +341,8 @@ cc_library(
         ":base_lib",
     ] + proxy_wasm_select_engine_null(
         [":null_lib"],
+    ) + proxy_wasm_select_engine_dyn(
+        [":dyn_lib"],
     ) + proxy_wasm_select_engine_v8(
         [":v8_lib"],
     ) + proxy_wasm_select_engine_wamr(

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -22,6 +22,11 @@ config_setting(
 )
 
 config_setting(
+    name = "engine_dyn",
+    values = {"define": "engine=dyn"},
+)
+
+config_setting(
     name = "engine_v8",
     values = {"define": "engine=v8"},
 )

--- a/bazel/select.bzl
+++ b/bazel/select.bzl
@@ -19,6 +19,13 @@ def proxy_wasm_select_engine_null(xs):
         "//conditions:default": [],
     })
 
+def proxy_wasm_select_engine_dyn(xs):
+    return select({
+        "@proxy_wasm_cpp_host//bazel:engine_dyn": xs,
+        "@proxy_wasm_cpp_host//bazel:multiengine": xs,
+        "//conditions:default": [],
+    })
+
 def proxy_wasm_select_engine_v8(xs):
     return select({
         "@proxy_wasm_cpp_host//bazel:engine_v8": xs,

--- a/bazel/wasm.bzl
+++ b/bazel/wasm.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_shared_library")
 
 def _wasm_rust_transition_impl(settings, attr):
     return {
@@ -59,12 +60,28 @@ def _wasm_binary_impl(ctx):
 
     return [DefaultInfo(files = depset([out]), runfiles = ctx.runfiles([out]))]
 
+def _dyn_binary_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.run(
+        executable = "cp",
+        arguments = [ctx.files.binary[0].path, out.path],
+        outputs = [out],
+        inputs = ctx.files.binary,
+    )
+
+    return [DefaultInfo(files = depset([out]), runfiles = ctx.runfiles([out]))]
+
 def _wasm_attrs(transition):
     return {
         "binary": attr.label(mandatory = True, cfg = transition),
         "signing_key": attr.label_list(allow_files = True),
         "_wasmsign_tool": attr.label(default = "//bazel/cargo/wasmsign/remote:wasmsign__wasmsign", executable = True, cfg = "exec"),
         "_whitelist_function_transition": attr.label(default = "@bazel_tools//tools/whitelists/function_transition_whitelist"),
+    }
+
+def _dyn_attrs():
+    return {
+        "binary": attr.label(mandatory = True),
     }
 
 wasm_rust_binary_rule = rule(
@@ -75,6 +92,11 @@ wasm_rust_binary_rule = rule(
 wasi_rust_binary_rule = rule(
     implementation = _wasm_binary_impl,
     attrs = _wasm_attrs(wasi_rust_transition),
+)
+
+dyn_rust_binary_rule = rule(
+    implementation = _dyn_binary_impl,
+    attrs = _dyn_attrs(),
 )
 
 def wasm_rust_binary(name, tags = [], wasi = False, signing_key = [], **kwargs):
@@ -98,5 +120,22 @@ def wasm_rust_binary(name, tags = [], wasi = False, signing_key = [], **kwargs):
         name = name,
         binary = ":" + wasm_name,
         signing_key = signing_key,
+        tags = tags + ["manual"],
+    )
+
+def dyn_rust_library(name, tags = [], **kwargs):
+    dyn_name = "_dyn_" + name.replace(".", "_")
+    kwargs.setdefault("visibility", ["//visibility:public"])
+
+    rust_shared_library(
+        name = dyn_name,
+        edition = "2018",
+        tags = ["manual"],
+        **kwargs
+    )
+
+    dyn_rust_binary_rule(
+        name = name,
+        binary = ":" + dyn_name,
         tags = tags + ["manual"],
     )

--- a/include/proxy-wasm/dyn.h
+++ b/include/proxy-wasm/dyn.h
@@ -1,0 +1,25 @@
+// Copyright 2016-2019 Envoy Project Authors
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+namespace proxy_wasm {
+
+class WasmVm;
+std::unique_ptr<WasmVm> createDynVm();
+
+} // namespace proxy_wasm

--- a/include/proxy-wasm/dyn_vm.h
+++ b/include/proxy-wasm/dyn_vm.h
@@ -24,9 +24,6 @@
 
 namespace proxy_wasm {
 
-class WasmVm;
-std::unique_ptr<WasmVm> createDynVm();
-
 // The DynVm wraps a C++ Wasm plugin which has been compiled with the Wasm API
 // and dynamically linked into the proxy.
 struct DynVm : public WasmVm {

--- a/include/proxy-wasm/dyn_vm.h
+++ b/include/proxy-wasm/dyn_vm.h
@@ -1,0 +1,70 @@
+// Copyright 2016-2019 Envoy Project Authors
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "include/proxy-wasm/dyn_vm_plugin.h"
+#include "include/proxy-wasm/wasm_vm.h"
+
+namespace proxy_wasm {
+
+class WasmVm;
+std::unique_ptr<WasmVm> createDynVm();
+
+// The DynVm wraps a C++ Wasm plugin which has been compiled with the Wasm API
+// and dynamically linked into the proxy.
+struct DynVm : public WasmVm {
+  DynVm() : WasmVm() {}
+
+  // WasmVm
+  std::string_view getEngineName() override { return "dyn"; }
+  Cloneable cloneable() override { return Cloneable::InstantiatedModule; };
+  std::unique_ptr<WasmVm> clone() override;
+  bool load(std::string_view plugin_name, std::string_view precompiled,
+            const std::unordered_map<uint32_t, std::string> &function_names) override;
+  bool link(std::string_view debug_name) override;
+  uint64_t getMemorySize() override;
+  std::optional<std::string_view> getMemory(uint64_t pointer, uint64_t size) override;
+  bool setMemory(uint64_t pointer, uint64_t size, const void *data) override;
+  bool setWord(uint64_t pointer, Word data) override;
+  bool getWord(uint64_t pointer, Word *data) override;
+  size_t getWordSize() override;
+  std::string_view getPrecompiledSectionName() override;
+
+#define _FORWARD_GET_FUNCTION(_T)                                                                  \
+  void getFunction(std::string_view function_name, _T *f) override {                               \
+    plugin_->getFunction(function_name, f);                                                        \
+  }
+  FOR_ALL_WASM_VM_EXPORTS(_FORWARD_GET_FUNCTION)
+#undef _FORWARD_GET_FUNCTION
+
+  // These are not needed for DynVm which invokes the handlers directly.
+#define _REGISTER_CALLBACK(_T)                                                                     \
+  void registerCallback(std::string_view, std::string_view, _T,                                    \
+                        typename ConvertFunctionTypeWordToUint32<_T>::type) override{};
+  FOR_ALL_WASM_VM_IMPORTS(_REGISTER_CALLBACK)
+#undef _REGISTER_CALLBACK
+
+  void terminate() override {}
+  bool usesWasmByteOrder() override { return false; }
+
+  std::unique_ptr<DynVmPlugin> plugin_;
+};
+
+} // namespace proxy_wasm

--- a/include/proxy-wasm/dyn_vm_plugin.h
+++ b/include/proxy-wasm/dyn_vm_plugin.h
@@ -1,0 +1,45 @@
+// Copyright 2016-2019 Envoy Project Authors
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "include/proxy-wasm/wasm_vm.h"
+
+namespace proxy_wasm {
+
+class DynVmPluginSource {
+public:
+  virtual ~DynVmPluginSource();
+  void *dl_handle = nullptr;
+  int memfd = -1;
+};
+
+// A wrapper for the dynamically linked DynVm plugin which implements the Wasm ABI.
+class DynVmPlugin {
+public:
+  DynVmPlugin() = default;
+  virtual ~DynVmPlugin() = default;
+
+  // NB: These are defined rather than declared PURE because gmock uses __LINE__ internally for
+  // uniqueness, making it impossible to use FOR_ALL_WASM_VM_EXPORTS with MOCK_METHOD.
+#define _DEFINE_GET_FUNCTION(_T) virtual void getFunction(std::string_view, _T *f);
+  FOR_ALL_WASM_VM_EXPORTS(_DEFINE_GET_FUNCTION)
+#undef _DEFINE_GET_FUNCTION
+
+  WasmVm *wasm_vm_ = nullptr;
+  std::shared_ptr<DynVmPluginSource> source;
+};
+
+} // namespace proxy_wasm

--- a/include/proxy-wasm/exports.h
+++ b/include/proxy-wasm/exports.h
@@ -149,6 +149,10 @@ Word wasi_unstable_random_get(Word, Word);
 Word pthread_equal(Word left, Word right);
 void emscripten_notify_memory_growth(Word);
 
+Word set_effective_context(Word context_id);
+void setLimitedEffectiveContext(ContextBase *context);
+ContextBase *getBaseContext();
+
 // Support for embedders, not exported to Wasm.
 
 #define FOR_ALL_HOST_FUNCTIONS(_f)                                                                 \

--- a/src/dyn/dyn.cc
+++ b/src/dyn/dyn.cc
@@ -1,0 +1,22 @@
+// Copyright 2016-2019 Envoy Project Authors
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "include/proxy-wasm/dyn_vm.h"
+
+namespace proxy_wasm {
+
+std::unique_ptr<WasmVm> createDynVm() { return std::make_unique<DynVm>(); }
+
+} // namespace proxy_wasm

--- a/src/dyn/dyn.cc
+++ b/src/dyn/dyn.cc
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "include/proxy-wasm/dyn.h"
 #include "include/proxy-wasm/dyn_vm.h"
 
 namespace proxy_wasm {

--- a/src/dyn/dyn_ffi.cc
+++ b/src/dyn/dyn_ffi.cc
@@ -15,243 +15,241 @@
 
 #include "include/proxy-wasm/wasm_vm.h"
 #include "include/proxy-wasm/wasm_api_impl.h"
-
-inline uint32_t wasmResultToWord(proxy_wasm::WasmResult result) {
-  return static_cast<size_t>(result);
-}
+#include <stddef.h>
 
 extern "C" {
 
 // Configuration and Status
-extern size_t proxy_get_configuration(const char **configuration_ptr, size_t *configuration_size) {
-  return wasmResultToWord(
-      proxy_wasm::null_plugin::proxy_get_configuration(configuration_ptr, configuration_size));
+extern proxy_wasm::WasmResult proxy_get_configuration(const char **configuration_ptr,
+                                                      size_t *configuration_size) {
+  return proxy_wasm::null_plugin::proxy_get_configuration(configuration_ptr, configuration_size);
 }
 
-uint32_t proxy_get_status(uint32_t *code_ptr, const char **ptr, size_t *size) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_status(code_ptr, ptr, size));
+proxy_wasm::WasmResult proxy_get_status(uint32_t *code_ptr, const char **ptr, size_t *size) {
+  return proxy_wasm::null_plugin::proxy_get_status(code_ptr, ptr, size);
 }
 
 // Logging
-uint32_t proxy_log(proxy_wasm::LogLevel level, const char *logMessage, size_t messageSize) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_log(level, logMessage, messageSize));
+proxy_wasm::WasmResult proxy_log(proxy_wasm::LogLevel level, const char *logMessage,
+                                 size_t messageSize) {
+  return proxy_wasm::null_plugin::proxy_log(level, logMessage, messageSize);
 }
-uint32_t proxy_get_log_level(proxy_wasm::LogLevel *level) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_log_level(level));
+proxy_wasm::WasmResult proxy_get_log_level(proxy_wasm::LogLevel *level) {
+  return proxy_wasm::null_plugin::proxy_get_log_level(level);
 }
 
 // Timer
-uint32_t proxy_set_tick_period_milliseconds(uint64_t millisecond) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_set_tick_period_milliseconds(millisecond));
+proxy_wasm::WasmResult proxy_set_tick_period_milliseconds(uint64_t millisecond) {
+  return proxy_wasm::null_plugin::proxy_set_tick_period_milliseconds(millisecond);
 }
-uint32_t proxy_get_current_time_nanoseconds(uint64_t *result) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_current_time_nanoseconds(result));
+proxy_wasm::WasmResult proxy_get_current_time_nanoseconds(uint64_t *result) {
+  return proxy_wasm::null_plugin::proxy_get_current_time_nanoseconds(result);
 }
 
 // State accessors
-uint32_t proxy_get_property(const char *path_ptr, size_t path_size, const char **value_ptr_ptr,
-                            size_t *value_size_ptr) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_property(
-      path_ptr, path_size, value_ptr_ptr, value_size_ptr));
+proxy_wasm::WasmResult proxy_get_property(const char *path_ptr, size_t path_size,
+                                          const char **value_ptr_ptr, size_t *value_size_ptr) {
+  return proxy_wasm::null_plugin::proxy_get_property(path_ptr, path_size, value_ptr_ptr,
+                                                     value_size_ptr);
 }
-uint32_t proxy_set_property(const char *key_ptr, size_t key_size, const char *value_ptr,
-                            size_t value_size) {
-  return wasmResultToWord(
-      proxy_wasm::null_plugin::proxy_set_property(key_ptr, key_size, value_ptr, value_size));
+proxy_wasm::WasmResult proxy_set_property(const char *key_ptr, size_t key_size,
+                                          const char *value_ptr, size_t value_size) {
+  return proxy_wasm::null_plugin::proxy_set_property(key_ptr, key_size, value_ptr, value_size);
 }
 
 // Continue
-uint32_t proxy_continue_request() {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_continue_request());
+proxy_wasm::WasmResult proxy_continue_request() {
+  return proxy_wasm::null_plugin::proxy_continue_request();
 }
-uint32_t proxy_continue_response() {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_continue_response());
+proxy_wasm::WasmResult proxy_continue_response() {
+  return proxy_wasm::null_plugin::proxy_continue_response();
 }
-uint32_t proxy_continue_stream(proxy_wasm::WasmStreamType stream_type) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_continue_stream(stream_type));
+proxy_wasm::WasmResult proxy_continue_stream(proxy_wasm::WasmStreamType stream_type) {
+  return proxy_wasm::null_plugin::proxy_continue_stream(stream_type);
 }
-uint32_t proxy_close_stream(proxy_wasm::WasmStreamType stream_type) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_close_stream(stream_type));
+proxy_wasm::WasmResult proxy_close_stream(proxy_wasm::WasmStreamType stream_type) {
+  return proxy_wasm::null_plugin::proxy_close_stream(stream_type);
 }
-uint32_t proxy_send_local_response(uint32_t response_code, const char *response_code_details_ptr,
-                                   size_t response_code_details_size, const char *body_ptr,
-                                   size_t body_size,
-                                   const char *additional_response_header_pairs_ptr,
-                                   size_t additional_response_header_pairs_size,
-                                   uint32_t grpc_status) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_send_local_response(
+proxy_wasm::WasmResult
+proxy_send_local_response(uint32_t response_code, const char *response_code_details_ptr,
+                          size_t response_code_details_size, const char *body_ptr, size_t body_size,
+                          const char *additional_response_header_pairs_ptr,
+                          size_t additional_response_header_pairs_size, uint32_t grpc_status) {
+  return proxy_wasm::null_plugin::proxy_send_local_response(
       response_code, response_code_details_ptr, response_code_details_size, body_ptr, body_size,
-      additional_response_header_pairs_ptr, additional_response_header_pairs_size, grpc_status));
+      additional_response_header_pairs_ptr, additional_response_header_pairs_size, grpc_status);
 }
 
-uint32_t proxy_clear_route_cache() {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_clear_route_cache());
+proxy_wasm::WasmResult proxy_clear_route_cache() {
+  return proxy_wasm::null_plugin::proxy_clear_route_cache();
 }
 
 // SharedData
-uint32_t proxy_get_shared_data(const char *key_ptr, size_t key_size, const char **value_ptr,
-                               size_t *value_size, uint32_t *cas) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_shared_data(
-      key_ptr, key_size, value_ptr, value_size, cas));
+proxy_wasm::WasmResult proxy_get_shared_data(const char *key_ptr, size_t key_size,
+                                             const char **value_ptr, size_t *value_size,
+                                             uint32_t *cas) {
+  return proxy_wasm::null_plugin::proxy_get_shared_data(key_ptr, key_size, value_ptr, value_size,
+                                                        cas);
 }
 //  If cas != 0 and cas != the current cas for 'key' return false, otherwise set the value and
 //  return true.
-uint32_t proxy_set_shared_data(const char *key_ptr, size_t key_size, const char *value_ptr,
-                               size_t value_size, uint64_t cas) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_set_shared_data(
-      key_ptr, key_size, value_ptr, value_size, cas));
+proxy_wasm::WasmResult proxy_set_shared_data(const char *key_ptr, size_t key_size,
+                                             const char *value_ptr, size_t value_size,
+                                             uint64_t cas) {
+  return proxy_wasm::null_plugin::proxy_set_shared_data(key_ptr, key_size, value_ptr, value_size,
+                                                        cas);
 }
 
 // SharedQueue
 // Note: Registering the same queue_name will overwrite the old registration while preseving any
 // pending data. Consequently it should typically be followed by a call to
 // proxy_dequeue_shared_queue. Returns unique token for the queue.
-uint32_t proxy_register_shared_queue(const char *queue_name_ptr, size_t queue_name_size,
-                                     uint32_t *token) {
-  return wasmResultToWord(
-      proxy_wasm::null_plugin::proxy_register_shared_queue(queue_name_ptr, queue_name_size, token));
+proxy_wasm::WasmResult proxy_register_shared_queue(const char *queue_name_ptr,
+                                                   size_t queue_name_size, uint32_t *token) {
+  return proxy_wasm::null_plugin::proxy_register_shared_queue(queue_name_ptr, queue_name_size,
+                                                              token);
 }
 // Returns unique token for the queue.
-uint32_t proxy_resolve_shared_queue(const char *vm_id_ptr, size_t vm_id_size,
-                                    const char *queue_name_ptr, size_t queue_name_size,
-                                    uint32_t *token) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_resolve_shared_queue(
-      vm_id_ptr, vm_id_size, queue_name_ptr, queue_name_size, token));
+proxy_wasm::WasmResult proxy_resolve_shared_queue(const char *vm_id_ptr, size_t vm_id_size,
+                                                  const char *queue_name_ptr,
+                                                  size_t queue_name_size, uint32_t *token) {
+  return proxy_wasm::null_plugin::proxy_resolve_shared_queue(vm_id_ptr, vm_id_size, queue_name_ptr,
+                                                             queue_name_size, token);
 }
 // Returns true on end-of-stream (no more data available).
-uint32_t proxy_dequeue_shared_queue(uint32_t token, const char **data_ptr, size_t *data_size) {
-  return wasmResultToWord(
-      proxy_wasm::null_plugin::proxy_dequeue_shared_queue(token, data_ptr, data_size));
+proxy_wasm::WasmResult proxy_dequeue_shared_queue(uint32_t token, const char **data_ptr,
+                                                  size_t *data_size) {
+  return proxy_wasm::null_plugin::proxy_dequeue_shared_queue(token, data_ptr, data_size);
 }
 // Returns false if the queue was not found and the data was not enqueued.
-uint32_t proxy_enqueue_shared_queue(uint32_t token, const char *data_ptr, size_t data_size) {
-  return wasmResultToWord(
-      proxy_wasm::null_plugin::proxy_enqueue_shared_queue(token, data_ptr, data_size));
+proxy_wasm::WasmResult proxy_enqueue_shared_queue(uint32_t token, const char *data_ptr,
+                                                  size_t data_size) {
+  return proxy_wasm::null_plugin::proxy_enqueue_shared_queue(token, data_ptr, data_size);
 }
 
 // Buffer
-uint32_t proxy_get_buffer_bytes(proxy_wasm::WasmBufferType type, size_t start, size_t length,
-                                const char **ptr, size_t *size) {
-  return wasmResultToWord(
-      proxy_wasm::null_plugin::proxy_get_buffer_bytes(type, start, length, ptr, size));
+proxy_wasm::WasmResult proxy_get_buffer_bytes(proxy_wasm::WasmBufferType type, size_t start,
+                                              size_t length, const char **ptr, size_t *size) {
+  return proxy_wasm::null_plugin::proxy_get_buffer_bytes(type, start, length, ptr, size);
 }
 
-uint32_t proxy_get_buffer_status(proxy_wasm::WasmBufferType type, size_t *length_ptr,
-                                 uint32_t *flags_ptr) {
-  return wasmResultToWord(
-      proxy_wasm::null_plugin::proxy_get_buffer_status(type, length_ptr, flags_ptr));
+proxy_wasm::WasmResult proxy_get_buffer_status(proxy_wasm::WasmBufferType type, size_t *length_ptr,
+                                               uint32_t *flags_ptr) {
+  return proxy_wasm::null_plugin::proxy_get_buffer_status(type, length_ptr, flags_ptr);
 }
 
-uint32_t proxy_set_buffer_bytes(proxy_wasm::WasmBufferType type, uint64_t start, uint64_t length,
-                                const char *data, size_t size) {
-  return wasmResultToWord(
-      proxy_wasm::null_plugin::proxy_set_buffer_bytes(type, start, length, data, size));
+proxy_wasm::WasmResult proxy_set_buffer_bytes(proxy_wasm::WasmBufferType type, uint64_t start,
+                                              uint64_t length, const char *data, size_t size) {
+  return proxy_wasm::null_plugin::proxy_set_buffer_bytes(type, start, length, data, size);
 }
 
 // Headers/Trailers/Metadata Maps
-uint32_t proxy_add_header_map_value(proxy_wasm::WasmHeaderMapType type, const char *key_ptr,
-                                    size_t key_size, const char *value_ptr, size_t value_size) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_add_header_map_value(
-      type, key_ptr, key_size, value_ptr, value_size));
+proxy_wasm::WasmResult proxy_add_header_map_value(proxy_wasm::WasmHeaderMapType type,
+                                                  const char *key_ptr, size_t key_size,
+                                                  const char *value_ptr, size_t value_size) {
+  return proxy_wasm::null_plugin::proxy_add_header_map_value(type, key_ptr, key_size, value_ptr,
+                                                             value_size);
 }
-uint32_t proxy_get_header_map_value(proxy_wasm::WasmHeaderMapType type, const char *key_ptr,
-                                    size_t key_size, const char **value_ptr, size_t *value_size) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_header_map_value(
-      type, key_ptr, key_size, value_ptr, value_size));
+proxy_wasm::WasmResult proxy_get_header_map_value(proxy_wasm::WasmHeaderMapType type,
+                                                  const char *key_ptr, size_t key_size,
+                                                  const char **value_ptr, size_t *value_size) {
+  return proxy_wasm::null_plugin::proxy_get_header_map_value(type, key_ptr, key_size, value_ptr,
+                                                             value_size);
 }
-uint32_t proxy_get_header_map_pairs(proxy_wasm::WasmHeaderMapType type, const char **ptr,
-                                    size_t *size) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_header_map_pairs(type, ptr, size));
+proxy_wasm::WasmResult proxy_get_header_map_pairs(proxy_wasm::WasmHeaderMapType type,
+                                                  const char **ptr, size_t *size) {
+  return proxy_wasm::null_plugin::proxy_get_header_map_pairs(type, ptr, size);
 }
-uint32_t proxy_set_header_map_pairs(proxy_wasm::WasmHeaderMapType type, const char *ptr,
-                                    size_t size) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_set_header_map_pairs(type, ptr, size));
+proxy_wasm::WasmResult proxy_set_header_map_pairs(proxy_wasm::WasmHeaderMapType type,
+                                                  const char *ptr, size_t size) {
+  return proxy_wasm::null_plugin::proxy_set_header_map_pairs(type, ptr, size);
 }
-uint32_t proxy_replace_header_map_value(proxy_wasm::WasmHeaderMapType type, const char *key_ptr,
-                                        size_t key_size, const char *value_ptr, size_t value_size) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_replace_header_map_value(
-      type, key_ptr, key_size, value_ptr, value_size));
+proxy_wasm::WasmResult proxy_replace_header_map_value(proxy_wasm::WasmHeaderMapType type,
+                                                      const char *key_ptr, size_t key_size,
+                                                      const char *value_ptr, size_t value_size) {
+  return proxy_wasm::null_plugin::proxy_replace_header_map_value(type, key_ptr, key_size, value_ptr,
+                                                                 value_size);
 }
-uint32_t proxy_remove_header_map_value(proxy_wasm::WasmHeaderMapType type, const char *key_ptr,
-                                       size_t key_size) {
-  return wasmResultToWord(
-      proxy_wasm::null_plugin::proxy_remove_header_map_value(type, key_ptr, key_size));
+proxy_wasm::WasmResult proxy_remove_header_map_value(proxy_wasm::WasmHeaderMapType type,
+                                                     const char *key_ptr, size_t key_size) {
+  return proxy_wasm::null_plugin::proxy_remove_header_map_value(type, key_ptr, key_size);
 }
-uint32_t proxy_get_header_map_size(proxy_wasm::WasmHeaderMapType type, size_t *size) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_header_map_size(type, size));
+proxy_wasm::WasmResult proxy_get_header_map_size(proxy_wasm::WasmHeaderMapType type, size_t *size) {
+  return proxy_wasm::null_plugin::proxy_get_header_map_size(type, size);
 }
 
 // HTTP
 // Returns token, used in callback onHttpCallResponse
-uint32_t proxy_http_call(const char *uri_ptr, size_t uri_size, void *header_pairs_ptr,
-                         size_t header_pairs_size, const char *body_ptr, size_t body_size,
-                         void *trailer_pairs_ptr, size_t trailer_pairs_size,
-                         uint64_t timeout_milliseconds, uint32_t *token_ptr) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_http_call(
+proxy_wasm::WasmResult proxy_http_call(const char *uri_ptr, size_t uri_size, void *header_pairs_ptr,
+                                       size_t header_pairs_size, const char *body_ptr,
+                                       size_t body_size, void *trailer_pairs_ptr,
+                                       size_t trailer_pairs_size, uint64_t timeout_milliseconds,
+                                       uint32_t *token_ptr) {
+  return proxy_wasm::null_plugin::proxy_http_call(
       uri_ptr, uri_size, header_pairs_ptr, header_pairs_size, body_ptr, body_size,
-      trailer_pairs_ptr, trailer_pairs_size, timeout_milliseconds, token_ptr));
+      trailer_pairs_ptr, trailer_pairs_size, timeout_milliseconds, token_ptr);
 }
 // gRPC
 // Returns token, used in gRPC callbacks (onGrpc...)
-uint32_t proxy_grpc_call(const char *service_ptr, size_t service_size, const char *service_name_ptr,
-                         size_t service_name_size, const char *method_name_ptr,
-                         size_t method_name_size, void *initial_metadata_ptr,
-                         size_t initial_metadata_size, const char *request_ptr, size_t request_size,
-                         uint64_t timeout_milliseconds, uint32_t *token_ptr) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_grpc_call(
+proxy_wasm::WasmResult proxy_grpc_call(const char *service_ptr, size_t service_size,
+                                       const char *service_name_ptr, size_t service_name_size,
+                                       const char *method_name_ptr, size_t method_name_size,
+                                       void *initial_metadata_ptr, size_t initial_metadata_size,
+                                       const char *request_ptr, size_t request_size,
+                                       uint64_t timeout_milliseconds, uint32_t *token_ptr) {
+  return proxy_wasm::null_plugin::proxy_grpc_call(
       service_ptr, service_size, service_name_ptr, service_name_size, method_name_ptr,
       method_name_size, initial_metadata_ptr, initial_metadata_size, request_ptr, request_size,
-      timeout_milliseconds, token_ptr));
+      timeout_milliseconds, token_ptr);
 }
-uint32_t proxy_grpc_stream(const char *service_ptr, size_t service_size,
-                           const char *service_name_ptr, size_t service_name_size,
-                           const char *method_name_ptr, size_t method_name_size,
-                           void *initial_metadata_ptr, size_t initial_metadata_size,
-                           uint32_t *token_ptr) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_grpc_stream(
+proxy_wasm::WasmResult proxy_grpc_stream(const char *service_ptr, size_t service_size,
+                                         const char *service_name_ptr, size_t service_name_size,
+                                         const char *method_name_ptr, size_t method_name_size,
+                                         void *initial_metadata_ptr, size_t initial_metadata_size,
+                                         uint32_t *token_ptr) {
+  return proxy_wasm::null_plugin::proxy_grpc_stream(
       service_ptr, service_size, service_name_ptr, service_name_size, method_name_ptr,
-      method_name_size, initial_metadata_ptr, initial_metadata_size, token_ptr));
+      method_name_size, initial_metadata_ptr, initial_metadata_size, token_ptr);
 }
-uint32_t proxy_grpc_cancel(uint64_t token) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_grpc_cancel(token));
+proxy_wasm::WasmResult proxy_grpc_cancel(uint64_t token) {
+  return proxy_wasm::null_plugin::proxy_grpc_cancel(token);
 }
-uint32_t proxy_grpc_close(uint64_t token) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_grpc_close(token));
+proxy_wasm::WasmResult proxy_grpc_close(uint64_t token) {
+  return proxy_wasm::null_plugin::proxy_grpc_close(token);
 }
-uint32_t proxy_grpc_send(uint64_t token, const char *message_ptr, size_t message_size,
-                         uint64_t end_stream) {
-  return wasmResultToWord(
-      proxy_wasm::null_plugin::proxy_grpc_send(token, message_ptr, message_size, end_stream));
+proxy_wasm::WasmResult proxy_grpc_send(uint64_t token, const char *message_ptr, size_t message_size,
+                                       uint64_t end_stream) {
+  return proxy_wasm::null_plugin::proxy_grpc_send(token, message_ptr, message_size, end_stream);
 }
 
 // Metrics
 // Returns a metric_id which can be used to report a metric. On error returns 0.
-uint32_t proxy_define_metric(proxy_wasm::MetricType type, const char *name_ptr, size_t name_size,
-                             uint32_t *metric_id) {
-  return wasmResultToWord(
-      proxy_wasm::null_plugin::proxy_define_metric(type, name_ptr, name_size, metric_id));
+proxy_wasm::WasmResult proxy_define_metric(proxy_wasm::MetricType type, const char *name_ptr,
+                                           size_t name_size, uint32_t *metric_id) {
+  return proxy_wasm::null_plugin::proxy_define_metric(type, name_ptr, name_size, metric_id);
 }
-uint32_t proxy_increment_metric(uint32_t metric_id, int64_t offset) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_increment_metric(metric_id, offset));
+proxy_wasm::WasmResult proxy_increment_metric(uint32_t metric_id, int64_t offset) {
+  return proxy_wasm::null_plugin::proxy_increment_metric(metric_id, offset);
 }
-uint32_t proxy_record_metric(uint32_t metric_id, uint64_t value) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_record_metric(metric_id, value));
+proxy_wasm::WasmResult proxy_record_metric(uint32_t metric_id, uint64_t value) {
+  return proxy_wasm::null_plugin::proxy_record_metric(metric_id, value);
 }
-uint32_t proxy_get_metric(uint32_t metric_id, uint64_t *value) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_metric(metric_id, value));
+proxy_wasm::WasmResult proxy_get_metric(uint32_t metric_id, uint64_t *value) {
+  return proxy_wasm::null_plugin::proxy_get_metric(metric_id, value);
 }
 
 // System
-uint32_t proxy_set_effective_context(uint64_t context_id) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_set_effective_context(context_id));
+proxy_wasm::WasmResult proxy_set_effective_context(uint64_t context_id) {
+  return proxy_wasm::null_plugin::proxy_set_effective_context(context_id);
 }
-uint32_t proxy_done() { return wasmResultToWord(proxy_wasm::null_plugin::proxy_done()); }
+proxy_wasm::WasmResult proxy_done() { return proxy_wasm::null_plugin::proxy_done(); }
 
-uint32_t proxy_call_foreign_function(const char *function_name, size_t function_name_size,
-                                     const char *arguments, size_t arguments_size, char **results,
-                                     size_t *results_size) {
-  return wasmResultToWord(proxy_wasm::null_plugin::proxy_call_foreign_function(
-      function_name, function_name_size, arguments, arguments_size, results, results_size));
+proxy_wasm::WasmResult proxy_call_foreign_function(const char *function_name,
+                                                   size_t function_name_size, const char *arguments,
+                                                   size_t arguments_size, char **results,
+                                                   size_t *results_size) {
+  return proxy_wasm::null_plugin::proxy_call_foreign_function(
+      function_name, function_name_size, arguments, arguments_size, results, results_size);
 }
 
 // following functions only exposed in dyn native contexts

--- a/src/dyn/dyn_ffi.cc
+++ b/src/dyn/dyn_ffi.cc
@@ -1,0 +1,267 @@
+// Copyright 2016-2019 Envoy Project Authors
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "include/proxy-wasm/wasm_vm.h"
+#include "include/proxy-wasm/wasm_api_impl.h"
+
+inline uint32_t wasmResultToWord(proxy_wasm::WasmResult result) {
+  return static_cast<size_t>(result);
+}
+
+extern "C" {
+
+// Configuration and Status
+extern size_t proxy_get_configuration(const char **configuration_ptr, size_t *configuration_size) {
+  return wasmResultToWord(
+      proxy_wasm::null_plugin::proxy_get_configuration(configuration_ptr, configuration_size));
+}
+
+uint32_t proxy_get_status(uint32_t *code_ptr, const char **ptr, size_t *size) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_status(code_ptr, ptr, size));
+}
+
+// Logging
+uint32_t proxy_log(proxy_wasm::LogLevel level, const char *logMessage, size_t messageSize) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_log(level, logMessage, messageSize));
+}
+uint32_t proxy_get_log_level(proxy_wasm::LogLevel *level) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_log_level(level));
+}
+
+// Timer
+uint32_t proxy_set_tick_period_milliseconds(uint64_t millisecond) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_set_tick_period_milliseconds(millisecond));
+}
+uint32_t proxy_get_current_time_nanoseconds(uint64_t *result) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_current_time_nanoseconds(result));
+}
+
+// State accessors
+uint32_t proxy_get_property(const char *path_ptr, size_t path_size, const char **value_ptr_ptr,
+                            size_t *value_size_ptr) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_property(
+      path_ptr, path_size, value_ptr_ptr, value_size_ptr));
+}
+uint32_t proxy_set_property(const char *key_ptr, size_t key_size, const char *value_ptr,
+                            size_t value_size) {
+  return wasmResultToWord(
+      proxy_wasm::null_plugin::proxy_set_property(key_ptr, key_size, value_ptr, value_size));
+}
+
+// Continue
+uint32_t proxy_continue_request() {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_continue_request());
+}
+uint32_t proxy_continue_response() {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_continue_response());
+}
+uint32_t proxy_continue_stream(proxy_wasm::WasmStreamType stream_type) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_continue_stream(stream_type));
+}
+uint32_t proxy_close_stream(proxy_wasm::WasmStreamType stream_type) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_close_stream(stream_type));
+}
+uint32_t proxy_send_local_response(uint32_t response_code, const char *response_code_details_ptr,
+                                   size_t response_code_details_size, const char *body_ptr,
+                                   size_t body_size,
+                                   const char *additional_response_header_pairs_ptr,
+                                   size_t additional_response_header_pairs_size,
+                                   uint32_t grpc_status) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_send_local_response(
+      response_code, response_code_details_ptr, response_code_details_size, body_ptr, body_size,
+      additional_response_header_pairs_ptr, additional_response_header_pairs_size, grpc_status));
+}
+
+uint32_t proxy_clear_route_cache() {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_clear_route_cache());
+}
+
+// SharedData
+uint32_t proxy_get_shared_data(const char *key_ptr, size_t key_size, const char **value_ptr,
+                               size_t *value_size, uint32_t *cas) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_shared_data(
+      key_ptr, key_size, value_ptr, value_size, cas));
+}
+//  If cas != 0 and cas != the current cas for 'key' return false, otherwise set the value and
+//  return true.
+uint32_t proxy_set_shared_data(const char *key_ptr, size_t key_size, const char *value_ptr,
+                               size_t value_size, uint64_t cas) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_set_shared_data(
+      key_ptr, key_size, value_ptr, value_size, cas));
+}
+
+// SharedQueue
+// Note: Registering the same queue_name will overwrite the old registration while preseving any
+// pending data. Consequently it should typically be followed by a call to
+// proxy_dequeue_shared_queue. Returns unique token for the queue.
+uint32_t proxy_register_shared_queue(const char *queue_name_ptr, size_t queue_name_size,
+                                     uint32_t *token) {
+  return wasmResultToWord(
+      proxy_wasm::null_plugin::proxy_register_shared_queue(queue_name_ptr, queue_name_size, token));
+}
+// Returns unique token for the queue.
+uint32_t proxy_resolve_shared_queue(const char *vm_id_ptr, size_t vm_id_size,
+                                    const char *queue_name_ptr, size_t queue_name_size,
+                                    uint32_t *token) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_resolve_shared_queue(
+      vm_id_ptr, vm_id_size, queue_name_ptr, queue_name_size, token));
+}
+// Returns true on end-of-stream (no more data available).
+uint32_t proxy_dequeue_shared_queue(uint32_t token, const char **data_ptr, size_t *data_size) {
+  return wasmResultToWord(
+      proxy_wasm::null_plugin::proxy_dequeue_shared_queue(token, data_ptr, data_size));
+}
+// Returns false if the queue was not found and the data was not enqueued.
+uint32_t proxy_enqueue_shared_queue(uint32_t token, const char *data_ptr, size_t data_size) {
+  return wasmResultToWord(
+      proxy_wasm::null_plugin::proxy_enqueue_shared_queue(token, data_ptr, data_size));
+}
+
+// Buffer
+uint32_t proxy_get_buffer_bytes(proxy_wasm::WasmBufferType type, size_t start, size_t length,
+                                const char **ptr, size_t *size) {
+  return wasmResultToWord(
+      proxy_wasm::null_plugin::proxy_get_buffer_bytes(type, start, length, ptr, size));
+}
+
+uint32_t proxy_get_buffer_status(proxy_wasm::WasmBufferType type, size_t *length_ptr,
+                                 uint32_t *flags_ptr) {
+  return wasmResultToWord(
+      proxy_wasm::null_plugin::proxy_get_buffer_status(type, length_ptr, flags_ptr));
+}
+
+uint32_t proxy_set_buffer_bytes(proxy_wasm::WasmBufferType type, uint64_t start, uint64_t length,
+                                const char *data, size_t size) {
+  return wasmResultToWord(
+      proxy_wasm::null_plugin::proxy_set_buffer_bytes(type, start, length, data, size));
+}
+
+// Headers/Trailers/Metadata Maps
+uint32_t proxy_add_header_map_value(proxy_wasm::WasmHeaderMapType type, const char *key_ptr,
+                                    size_t key_size, const char *value_ptr, size_t value_size) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_add_header_map_value(
+      type, key_ptr, key_size, value_ptr, value_size));
+}
+uint32_t proxy_get_header_map_value(proxy_wasm::WasmHeaderMapType type, const char *key_ptr,
+                                    size_t key_size, const char **value_ptr, size_t *value_size) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_header_map_value(
+      type, key_ptr, key_size, value_ptr, value_size));
+}
+uint32_t proxy_get_header_map_pairs(proxy_wasm::WasmHeaderMapType type, const char **ptr,
+                                    size_t *size) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_header_map_pairs(type, ptr, size));
+}
+uint32_t proxy_set_header_map_pairs(proxy_wasm::WasmHeaderMapType type, const char *ptr,
+                                    size_t size) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_set_header_map_pairs(type, ptr, size));
+}
+uint32_t proxy_replace_header_map_value(proxy_wasm::WasmHeaderMapType type, const char *key_ptr,
+                                        size_t key_size, const char *value_ptr, size_t value_size) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_replace_header_map_value(
+      type, key_ptr, key_size, value_ptr, value_size));
+}
+uint32_t proxy_remove_header_map_value(proxy_wasm::WasmHeaderMapType type, const char *key_ptr,
+                                       size_t key_size) {
+  return wasmResultToWord(
+      proxy_wasm::null_plugin::proxy_remove_header_map_value(type, key_ptr, key_size));
+}
+uint32_t proxy_get_header_map_size(proxy_wasm::WasmHeaderMapType type, size_t *size) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_header_map_size(type, size));
+}
+
+// HTTP
+// Returns token, used in callback onHttpCallResponse
+uint32_t proxy_http_call(const char *uri_ptr, size_t uri_size, void *header_pairs_ptr,
+                         size_t header_pairs_size, const char *body_ptr, size_t body_size,
+                         void *trailer_pairs_ptr, size_t trailer_pairs_size,
+                         uint64_t timeout_milliseconds, uint32_t *token_ptr) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_http_call(
+      uri_ptr, uri_size, header_pairs_ptr, header_pairs_size, body_ptr, body_size,
+      trailer_pairs_ptr, trailer_pairs_size, timeout_milliseconds, token_ptr));
+}
+// gRPC
+// Returns token, used in gRPC callbacks (onGrpc...)
+uint32_t proxy_grpc_call(const char *service_ptr, size_t service_size, const char *service_name_ptr,
+                         size_t service_name_size, const char *method_name_ptr,
+                         size_t method_name_size, void *initial_metadata_ptr,
+                         size_t initial_metadata_size, const char *request_ptr, size_t request_size,
+                         uint64_t timeout_milliseconds, uint32_t *token_ptr) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_grpc_call(
+      service_ptr, service_size, service_name_ptr, service_name_size, method_name_ptr,
+      method_name_size, initial_metadata_ptr, initial_metadata_size, request_ptr, request_size,
+      timeout_milliseconds, token_ptr));
+}
+uint32_t proxy_grpc_stream(const char *service_ptr, size_t service_size,
+                           const char *service_name_ptr, size_t service_name_size,
+                           const char *method_name_ptr, size_t method_name_size,
+                           void *initial_metadata_ptr, size_t initial_metadata_size,
+                           uint32_t *token_ptr) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_grpc_stream(
+      service_ptr, service_size, service_name_ptr, service_name_size, method_name_ptr,
+      method_name_size, initial_metadata_ptr, initial_metadata_size, token_ptr));
+}
+uint32_t proxy_grpc_cancel(uint64_t token) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_grpc_cancel(token));
+}
+uint32_t proxy_grpc_close(uint64_t token) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_grpc_close(token));
+}
+uint32_t proxy_grpc_send(uint64_t token, const char *message_ptr, size_t message_size,
+                         uint64_t end_stream) {
+  return wasmResultToWord(
+      proxy_wasm::null_plugin::proxy_grpc_send(token, message_ptr, message_size, end_stream));
+}
+
+// Metrics
+// Returns a metric_id which can be used to report a metric. On error returns 0.
+uint32_t proxy_define_metric(proxy_wasm::MetricType type, const char *name_ptr, size_t name_size,
+                             uint32_t *metric_id) {
+  return wasmResultToWord(
+      proxy_wasm::null_plugin::proxy_define_metric(type, name_ptr, name_size, metric_id));
+}
+uint32_t proxy_increment_metric(uint32_t metric_id, int64_t offset) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_increment_metric(metric_id, offset));
+}
+uint32_t proxy_record_metric(uint32_t metric_id, uint64_t value) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_record_metric(metric_id, value));
+}
+uint32_t proxy_get_metric(uint32_t metric_id, uint64_t *value) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_get_metric(metric_id, value));
+}
+
+// System
+uint32_t proxy_set_effective_context(uint64_t context_id) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_set_effective_context(context_id));
+}
+uint32_t proxy_done() { return wasmResultToWord(proxy_wasm::null_plugin::proxy_done()); }
+
+uint32_t proxy_call_foreign_function(const char *function_name, size_t function_name_size,
+                                     const char *arguments, size_t arguments_size, char **results,
+                                     size_t *results_size) {
+  return wasmResultToWord(proxy_wasm::null_plugin::proxy_call_foreign_function(
+      function_name, function_name_size, arguments, arguments_size, results, results_size));
+}
+
+// following functions only exposed in dyn native contexts
+
+void *proxy_dyn_get_thread_context() {
+  return reinterpret_cast<void *>(proxy_wasm::exports::getBaseContext());
+}
+
+void proxy_dyn_set_limited_thread_context(void *thread_context) {
+  proxy_wasm::exports::setLimitedEffectiveContext(
+      reinterpret_cast<proxy_wasm::ContextBase *>(thread_context));
+}
+}

--- a/src/dyn/dyn_vm.cc
+++ b/src/dyn/dyn_vm.cc
@@ -1,0 +1,135 @@
+// Copyright 2016-2019 Envoy Project Authors
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "include/proxy-wasm/dyn_vm.h"
+
+#include <cstring>
+
+#include <limits>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include <sys/mman.h>
+#include <dlfcn.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+namespace proxy_wasm {
+
+std::unique_ptr<WasmVm> DynVm::clone() {
+  auto cloned_vm = std::make_unique<DynVm>();
+  if (integration()) {
+    cloned_vm->integration().reset(integration()->clone());
+  }
+  cloned_vm->plugin_ = std::make_unique<DynVmPlugin>();
+  cloned_vm->plugin_->source = plugin_->source;
+  cloned_vm->plugin_->wasm_vm_ = cloned_vm.get();
+
+  return cloned_vm;
+}
+
+// "Load" the plugin by obtaining a pointer to it from the factory.
+bool DynVm::load(std::string_view shared_lib, std::string_view /*precompiled*/,
+                 const std::unordered_map<uint32_t, std::string> & /*function_names*/) {
+  plugin_ = std::make_unique<DynVmPlugin>();
+  plugin_->source = std::make_shared<DynVmPluginSource>();
+  // We make the syscall directly w/o the glibc wrapper, as glibc 1.27 is required, but Ubuntu 16
+  // which Istio uses runs glibc 1.23. plugin_->source->memfd = memfd_create("dyn_plugin", 0);
+  plugin_->source->memfd =
+      static_cast<int>(syscall(SYS_memfd_create, static_cast<const char *>("dyn_plugin"), 0));
+  if (plugin_->source->memfd < 0) {
+    integration()->error("failed to open memfd for dl: " + std::string(strerror(errno)));
+    return false;
+  }
+  char path[100];
+  snprintf(path, sizeof(path), "/proc/%u/fd/%d", getpid(), plugin_->source->memfd);
+
+  size_t written = 0;
+  ssize_t wrote;
+  const char *data = shared_lib.data();
+  while (written < shared_lib.size()) {
+    wrote = write(plugin_->source->memfd, data + written, shared_lib.length() - written);
+    if (wrote < 0) {
+      integration()->error("failed to write to memfd: " + std::string(strerror(errno)));
+      return false;
+    } else if (wrote == 0) {
+      integration()->error("failed to write to memfd, EOF on write");
+      return false;
+    }
+    written += wrote;
+  }
+  fsync(plugin_->source->memfd);
+
+  plugin_->source->dl_handle = dlopen(path, RTLD_NOW);
+  if (plugin_->source->dl_handle == nullptr) {
+    integration()->error("failed to open dl handle: " + std::string(dlerror()));
+    return false;
+  }
+
+  plugin_->wasm_vm_ = this;
+  return true;
+}
+
+bool DynVm::link(std::string_view /* name */) { return true; }
+
+uint64_t DynVm::getMemorySize() { return std::numeric_limits<uint64_t>::max(); }
+
+// NulVm pointers are just native pointers.
+std::optional<std::string_view> DynVm::getMemory(uint64_t pointer, uint64_t size) {
+  if (pointer == 0 && size != 0) {
+    return std::nullopt;
+  }
+  return std::string_view(reinterpret_cast<char *>(pointer), static_cast<size_t>(size));
+}
+
+bool DynVm::setMemory(uint64_t pointer, uint64_t size, const void *data) {
+  if (pointer == 0 || data == nullptr) {
+    if (size != 0) {
+      return false;
+    }
+    return true;
+  }
+  auto *p = reinterpret_cast<char *>(pointer);
+  memcpy(p, data, size);
+  return true;
+}
+
+bool DynVm::setWord(uint64_t pointer, Word data) {
+  if (pointer == 0) {
+    return false;
+  }
+  auto *p = reinterpret_cast<char *>(pointer);
+  memcpy(p, &data.u64_, sizeof(data.u64_));
+  return true;
+}
+
+bool DynVm::getWord(uint64_t pointer, Word *data) {
+  if (pointer == 0) {
+    return false;
+  }
+  auto *p = reinterpret_cast<char *>(pointer);
+  memcpy(&data->u64_, p, sizeof(data->u64_));
+  return true;
+}
+
+size_t DynVm::getWordSize() { return sizeof(uint64_t); }
+
+std::string_view DynVm::getPrecompiledSectionName() {
+  // Return nothing: there is no WASM file.
+  return {};
+}
+
+} // namespace proxy_wasm

--- a/src/dyn/dyn_vm_plugin.cc
+++ b/src/dyn/dyn_vm_plugin.cc
@@ -1,0 +1,217 @@
+// Copyright 2016-2019 Envoy Project Authors
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "include/proxy-wasm/wasm_vm.h"
+
+#include "include/proxy-wasm/dyn_vm_plugin.h"
+#include <iostream>
+#include <dlfcn.h>
+#include <thread>
+#include <sstream>
+#include <string>
+#include <stdexcept>
+#include <unistd.h>
+#include <cstdarg>
+
+namespace proxy_wasm {
+
+std::string get_tid() {
+  auto tid = std::this_thread::get_id();
+  std::stringstream stream;
+  stream << tid;
+  return stream.str();
+}
+
+std::string call_format(std::string_view function_name, int count, ...) {
+  std::stringstream out;
+  out << "dynamic call<" << get_tid() << ">: " << function_name << "(";
+  std::va_list args;
+  va_start(args, count);
+  for (int i = 0; i < count; ++i) {
+    uint64_t num = va_arg(args, uint64_t);
+    if (i > 0) {
+      out << ", ";
+    }
+    out << num;
+  }
+  out << ")";
+  va_end(args);
+  return out.str();
+}
+
+DynVmPluginSource::~DynVmPluginSource() {
+  if (dl_handle != nullptr) {
+    dlclose(dl_handle);
+  }
+  if (memfd >= 0) {
+    close(memfd);
+  }
+}
+
+void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallVoid<0> *f) {
+  if (source->dl_handle == NULL) {
+    *f = nullptr;
+    return;
+  }
+  void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
+  if (target == NULL) {
+    *f = nullptr;
+    return;
+  }
+  void (*target_func)() = reinterpret_cast<void (*)()>(target);
+  *f = [this, target_func, function_name](proxy_wasm::ContextBase *context) {
+    proxy_wasm::SaveRestoreContext saved_context(context);
+    wasm_vm_->integration()->trace(call_format(function_name, 0));
+    target_func();
+  };
+}
+
+void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallVoid<1> *f) {
+  if (source->dl_handle == NULL) {
+    *f = nullptr;
+    return;
+  }
+  void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
+  if (target == NULL) {
+    *f = nullptr;
+    return;
+  }
+  void (*target_func)(uint64_t) = reinterpret_cast<void (*)(uint64_t)>(target);
+  *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1) {
+    proxy_wasm::SaveRestoreContext saved_context(context);
+    wasm_vm_->integration()->trace(call_format(function_name, 1, w1));
+    target_func(w1.u64_);
+  };
+}
+
+void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallVoid<2> *f) {
+  if (source->dl_handle == NULL) {
+    *f = nullptr;
+    return;
+  }
+  void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
+  if (target == NULL) {
+    *f = nullptr;
+    return;
+  }
+  void (*target_func)(uint64_t, uint64_t) = reinterpret_cast<void (*)(uint64_t, uint64_t)>(target);
+  *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1,
+                                          proxy_wasm::Word w2) {
+    proxy_wasm::SaveRestoreContext saved_context(context);
+    wasm_vm_->integration()->trace(call_format(function_name, 2, w1, w2));
+    target_func(w1.u64_, w2.u64_);
+  };
+}
+
+void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallVoid<3> *f) {
+  if (source->dl_handle == NULL) {
+    *f = nullptr;
+    return;
+  }
+  void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
+  if (target == NULL) {
+    *f = nullptr;
+    return;
+  }
+  void (*target_func)(uint64_t, uint64_t, uint64_t) =
+      reinterpret_cast<void (*)(uint64_t, uint64_t, uint64_t)>(target);
+  *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1,
+                                          proxy_wasm::Word w2, proxy_wasm::Word w3) {
+    proxy_wasm::SaveRestoreContext saved_context(context);
+    wasm_vm_->integration()->trace(call_format(function_name, 3, w1, w2, w3));
+    target_func(w1.u64_, w2.u64_, w3.u64_);
+  };
+}
+
+void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallVoid<5> *f) {
+  if (source->dl_handle == NULL) {
+    *f = nullptr;
+    return;
+  }
+  void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
+  if (target == NULL) {
+    *f = nullptr;
+    return;
+  }
+  void (*target_func)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) =
+      reinterpret_cast<void (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t)>(target);
+  *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1,
+                                          proxy_wasm::Word w2, proxy_wasm::Word w3,
+                                          proxy_wasm::Word w4, proxy_wasm::Word w5) {
+    proxy_wasm::SaveRestoreContext saved_context(context);
+    wasm_vm_->integration()->trace(call_format(function_name, 5, w1, w2, w3, w4, w5));
+    target_func(w1.u64_, w2.u64_, w3.u64_, w4.u64_, w5.u64_);
+  };
+}
+
+void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallWord<1> *f) {
+  if (source->dl_handle == NULL || function_name == "malloc") {
+    *f = nullptr;
+    return;
+  }
+  void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
+  if (target == NULL) {
+    *f = nullptr;
+    return;
+  }
+  uint64_t (*target_func)(uint64_t) = reinterpret_cast<uint64_t (*)(uint64_t)>(target);
+  *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1) {
+    proxy_wasm::SaveRestoreContext saved_context(context);
+    wasm_vm_->integration()->trace(call_format(function_name, 1, w1));
+    return proxy_wasm::Word(target_func(w1.u64_));
+  };
+}
+
+void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallWord<2> *f) {
+  if (source->dl_handle == NULL) {
+    *f = nullptr;
+    return;
+  }
+  void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
+  if (target == NULL) {
+    *f = nullptr;
+    return;
+  }
+  uint64_t (*target_func)(uint64_t, uint64_t) =
+      reinterpret_cast<uint64_t (*)(uint64_t, uint64_t)>(target);
+  *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1,
+                                          proxy_wasm::Word w2) {
+    proxy_wasm::SaveRestoreContext saved_context(context);
+    wasm_vm_->integration()->trace(call_format(function_name, 2, w1, w2));
+    return proxy_wasm::Word(target_func(w1.u64_, w2.u64_));
+  };
+}
+
+void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallWord<3> *f) {
+  if (source->dl_handle == NULL) {
+    *f = nullptr;
+    return;
+  }
+  void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
+  if (target == NULL) {
+    *f = nullptr;
+    return;
+  }
+  uint64_t (*target_func)(uint64_t, uint64_t, uint64_t) =
+      reinterpret_cast<uint64_t (*)(uint64_t, uint64_t, uint64_t)>(target);
+  *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1,
+                                          proxy_wasm::Word w2, proxy_wasm::Word w3) {
+    proxy_wasm::SaveRestoreContext saved_context(context);
+    wasm_vm_->integration()->trace(call_format(function_name, 3, w1, w2, w3));
+    return proxy_wasm::Word(target_func(w1.u64_, w2.u64_, w3.u64_));
+  };
+}
+
+} // namespace proxy_wasm

--- a/src/dyn/dyn_vm_plugin.cc
+++ b/src/dyn/dyn_vm_plugin.cc
@@ -16,14 +16,14 @@
 #include "include/proxy-wasm/wasm_vm.h"
 
 #include "include/proxy-wasm/dyn_vm_plugin.h"
-#include <iostream>
-#include <dlfcn.h>
-#include <thread>
-#include <sstream>
-#include <string>
-#include <stdexcept>
-#include <unistd.h>
 #include <cstdarg>
+#include <dlfcn.h>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <unistd.h>
 
 namespace proxy_wasm {
 
@@ -61,16 +61,16 @@ DynVmPluginSource::~DynVmPluginSource() {
 }
 
 void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallVoid<0> *f) {
-  if (source->dl_handle == NULL) {
+  if (source->dl_handle == nullptr) {
     *f = nullptr;
     return;
   }
   void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
-  if (target == NULL) {
+  if (target == nullptr) {
     *f = nullptr;
     return;
   }
-  void (*target_func)() = reinterpret_cast<void (*)()>(target);
+  auto target_func = reinterpret_cast<void (*)()>(target);
   *f = [this, target_func, function_name](proxy_wasm::ContextBase *context) {
     proxy_wasm::SaveRestoreContext saved_context(context);
     wasm_vm_->integration()->trace(call_format(function_name, 0));
@@ -79,16 +79,16 @@ void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCa
 }
 
 void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallVoid<1> *f) {
-  if (source->dl_handle == NULL) {
+  if (source->dl_handle == nullptr) {
     *f = nullptr;
     return;
   }
   void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
-  if (target == NULL) {
+  if (target == nullptr) {
     *f = nullptr;
     return;
   }
-  void (*target_func)(uint64_t) = reinterpret_cast<void (*)(uint64_t)>(target);
+  auto target_func = reinterpret_cast<void (*)(uint64_t)>(target);
   *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1) {
     proxy_wasm::SaveRestoreContext saved_context(context);
     wasm_vm_->integration()->trace(call_format(function_name, 1, w1));
@@ -97,16 +97,16 @@ void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCa
 }
 
 void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallVoid<2> *f) {
-  if (source->dl_handle == NULL) {
+  if (source->dl_handle == nullptr) {
     *f = nullptr;
     return;
   }
   void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
-  if (target == NULL) {
+  if (target == nullptr) {
     *f = nullptr;
     return;
   }
-  void (*target_func)(uint64_t, uint64_t) = reinterpret_cast<void (*)(uint64_t, uint64_t)>(target);
+  auto target_func = reinterpret_cast<void (*)(uint64_t, uint64_t)>(target);
   *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1,
                                           proxy_wasm::Word w2) {
     proxy_wasm::SaveRestoreContext saved_context(context);
@@ -116,16 +116,16 @@ void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCa
 }
 
 void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallVoid<3> *f) {
-  if (source->dl_handle == NULL) {
+  if (source->dl_handle == nullptr) {
     *f = nullptr;
     return;
   }
   void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
-  if (target == NULL) {
+  if (target == nullptr) {
     *f = nullptr;
     return;
   }
-  void (*target_func)(uint64_t, uint64_t, uint64_t) =
+  auto target_func =
       reinterpret_cast<void (*)(uint64_t, uint64_t, uint64_t)>(target);
   *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1,
                                           proxy_wasm::Word w2, proxy_wasm::Word w3) {
@@ -136,16 +136,16 @@ void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCa
 }
 
 void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallVoid<5> *f) {
-  if (source->dl_handle == NULL) {
+  if (source->dl_handle == nullptr) {
     *f = nullptr;
     return;
   }
   void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
-  if (target == NULL) {
+  if (target == nullptr) {
     *f = nullptr;
     return;
   }
-  void (*target_func)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) =
+  auto target_func =
       reinterpret_cast<void (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t)>(target);
   *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1,
                                           proxy_wasm::Word w2, proxy_wasm::Word w3,
@@ -157,16 +157,16 @@ void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCa
 }
 
 void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallWord<1> *f) {
-  if (source->dl_handle == NULL || function_name == "malloc") {
+  if (source->dl_handle == nullptr || function_name == "malloc") {
     *f = nullptr;
     return;
   }
   void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
-  if (target == NULL) {
+  if (target == nullptr) {
     *f = nullptr;
     return;
   }
-  uint64_t (*target_func)(uint64_t) = reinterpret_cast<uint64_t (*)(uint64_t)>(target);
+  auto target_func = reinterpret_cast<uint64_t (*)(uint64_t)>(target);
   *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1) {
     proxy_wasm::SaveRestoreContext saved_context(context);
     wasm_vm_->integration()->trace(call_format(function_name, 1, w1));
@@ -175,16 +175,16 @@ void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCa
 }
 
 void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallWord<2> *f) {
-  if (source->dl_handle == NULL) {
+  if (source->dl_handle == nullptr) {
     *f = nullptr;
     return;
   }
   void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
-  if (target == NULL) {
+  if (target == nullptr) {
     *f = nullptr;
     return;
   }
-  uint64_t (*target_func)(uint64_t, uint64_t) =
+  auto target_func =
       reinterpret_cast<uint64_t (*)(uint64_t, uint64_t)>(target);
   *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1,
                                           proxy_wasm::Word w2) {
@@ -195,16 +195,16 @@ void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCa
 }
 
 void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCallWord<3> *f) {
-  if (source->dl_handle == NULL) {
+  if (source->dl_handle == nullptr) {
     *f = nullptr;
     return;
   }
   void *target = dlsym(source->dl_handle, std::string(function_name).c_str());
-  if (target == NULL) {
+  if (target == nullptr) {
     *f = nullptr;
     return;
   }
-  uint64_t (*target_func)(uint64_t, uint64_t, uint64_t) =
+  auto target_func =
       reinterpret_cast<uint64_t (*)(uint64_t, uint64_t, uint64_t)>(target);
   *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1,
                                           proxy_wasm::Word w2, proxy_wasm::Word w3) {

--- a/src/dyn/dyn_vm_plugin.cc
+++ b/src/dyn/dyn_vm_plugin.cc
@@ -125,8 +125,7 @@ void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCa
     *f = nullptr;
     return;
   }
-  auto target_func =
-      reinterpret_cast<void (*)(uint64_t, uint64_t, uint64_t)>(target);
+  auto target_func = reinterpret_cast<void (*)(uint64_t, uint64_t, uint64_t)>(target);
   *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1,
                                           proxy_wasm::Word w2, proxy_wasm::Word w3) {
     proxy_wasm::SaveRestoreContext saved_context(context);
@@ -184,8 +183,7 @@ void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCa
     *f = nullptr;
     return;
   }
-  auto target_func =
-      reinterpret_cast<uint64_t (*)(uint64_t, uint64_t)>(target);
+  auto target_func = reinterpret_cast<uint64_t (*)(uint64_t, uint64_t)>(target);
   *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1,
                                           proxy_wasm::Word w2) {
     proxy_wasm::SaveRestoreContext saved_context(context);
@@ -204,8 +202,7 @@ void DynVmPlugin::getFunction(std::string_view function_name, proxy_wasm::WasmCa
     *f = nullptr;
     return;
   }
-  auto target_func =
-      reinterpret_cast<uint64_t (*)(uint64_t, uint64_t, uint64_t)>(target);
+  auto target_func = reinterpret_cast<uint64_t (*)(uint64_t, uint64_t, uint64_t)>(target);
   *f = [this, target_func, function_name](proxy_wasm::ContextBase *context, proxy_wasm::Word w1,
                                           proxy_wasm::Word w2, proxy_wasm::Word w3) {
     proxy_wasm::SaveRestoreContext saved_context(context);

--- a/src/exports.cc
+++ b/src/exports.cc
@@ -48,6 +48,7 @@ ContextBase *contextOrEffectiveContextRoot() {
   return nullptr;
 };
 
+// Gets any currently executing Wasm call context, including a thread-sharable limited context.
 ContextBase *getLimitedContext() {
   if (limited_context_ != nullptr) {
     return limited_context_;

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -261,6 +261,15 @@ bool WasmBase::load(const std::string &code, bool allow_precompiled) {
     abi_version_ = AbiVersion::ProxyWasm_0_2_1;
     return true;
   }
+  if (wasm_vm_->getEngineName() == "dyn") {
+    auto ok = wasm_vm_->load(code, {}, {});
+    if (!ok) {
+      fail(FailState::UnableToInitializeCode, "Failed to load DynVM plugin");
+      return false;
+    }
+    abi_version_ = AbiVersion::ProxyWasm_0_2_1;
+    return true;
+  }
 
   // Verify signature.
   std::string message;

--- a/test/BUILD
+++ b/test/BUILD
@@ -181,6 +181,21 @@ cc_test(
 )
 
 cc_test(
+    name = "dyn_vm_test",
+    srcs = ["dyn_vm_test.cc"],
+    data = [
+        "//test/test_data:abi_export.so",
+    ],
+    linkstatic = 1,
+    deps = [
+        ":utility_lib",
+        "//:lib",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "wasm_vm_test",
     timeout = "long",
     srcs = ["wasm_vm_test.cc"],

--- a/test/dyn_vm_test.cc
+++ b/test/dyn_vm_test.cc
@@ -1,0 +1,99 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "include/proxy-wasm/wasm_vm.h"
+
+#include "test/utility.h"
+
+namespace proxy_wasm {
+namespace {
+
+std::vector<std::string> getDynEngines() {
+  std::vector<std::string> engines = {
+#if defined(PROXY_WASM_HOST_ENGINE_DYN)
+    "dyn",
+#endif
+    ""
+  };
+  engines.pop_back();
+  return engines;
+}
+
+INSTANTIATE_TEST_SUITE_P(WasmEngines, TestVm, testing::ValuesIn(getDynEngines()),
+                         [](const testing::TestParamInfo<std::string> &info) {
+                           return info.param;
+                         });
+
+TEST_P(TestVm, Basic) {
+  EXPECT_EQ(vm_->getEngineName(), engine_);
+  EXPECT_EQ(vm_->getEngineName(), "dyn");
+  EXPECT_EQ(vm_->cloneable(), proxy_wasm::Cloneable::InstantiatedModule);
+}
+
+TEST_P(TestVm, Memory) {
+  auto source = readTestWasmFile("abi_export.so");
+  ASSERT_TRUE(vm_->load(source, {}, {}));
+  ASSERT_TRUE(vm_->link(""));
+
+  uint64_t raw_word = 0;
+
+  Word word;
+  ASSERT_TRUE(vm_->setWord(reinterpret_cast<uint64_t>(&raw_word), Word(100)));
+  ASSERT_TRUE(vm_->getWord(reinterpret_cast<uint64_t>(&raw_word), &word));
+  ASSERT_EQ(100, word.u64_);
+  ASSERT_EQ(100, raw_word);
+
+  uint32_t raw_data[2] = {0, 0};
+
+  uint32_t data[2] = {htowasm(static_cast<uint32_t>(-1), vm_->usesWasmByteOrder()),
+                      htowasm(200, vm_->usesWasmByteOrder())};
+  ASSERT_TRUE(vm_->setMemory(reinterpret_cast<uint64_t>(&raw_data[0]), sizeof(int32_t) * 2,
+                             static_cast<void *>(data)));
+  ASSERT_TRUE(vm_->getWord(reinterpret_cast<uint64_t>(&raw_data[0]), &word));
+  ASSERT_EQ(-1, static_cast<int32_t>(word.u64_));
+  ASSERT_TRUE(vm_->getWord(reinterpret_cast<uint64_t>(&raw_data[1]), &word));
+  ASSERT_EQ(200, static_cast<int32_t>(word.u64_));
+}
+
+TEST_P(TestVm, ReadWrite) {
+  auto source = readTestWasmFile("abi_export.so");
+  ASSERT_TRUE(vm_->load(source, {}, {}));
+  ASSERT_TRUE(vm_->link(""));
+  BufferBase buffer;
+  buffer.set("test data");
+  uint64_t buffer_raw = 0;
+  uint64_t buffer_len = 0;
+  auto wasm = TestWasm(std::move(vm_), {});
+  ASSERT_TRUE(wasm.initialize());
+  ASSERT_EQ(buffer.copyTo(&wasm, 0, buffer.size(), reinterpret_cast<uint64_t>(&buffer_raw),
+                          reinterpret_cast<uint64_t>(&buffer_len)),
+            WasmResult::Ok);
+
+  ASSERT_NE(buffer_raw, 0);
+  ASSERT_NE(buffer_len, 0);
+
+  char *buffer_ptr = reinterpret_cast<char *>(buffer_raw);
+  ASSERT_EQ(buffer_len, buffer.size());
+  std::string buffer_str(buffer_ptr, buffer_ptr + buffer_len);
+  ASSERT_EQ(buffer_str, "test data");
+}
+
+} // namespace
+} // namespace proxy_wasm

--- a/test/test_data/BUILD
+++ b/test/test_data/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@proxy_wasm_cpp_host//bazel:wasm.bzl", "wasm_rust_binary")
+load("@proxy_wasm_cpp_host//bazel:wasm.bzl", "dyn_rust_library")
 load("@proxy_wasm_cpp_sdk//bazel:defs.bzl", "proxy_wasm_cc_binary")
 
 licenses(["notice"])  # Apache 2
@@ -21,6 +22,11 @@ package(default_visibility = ["//visibility:public"])
 
 wasm_rust_binary(
     name = "abi_export.wasm",
+    srcs = ["abi_export.rs"],
+)
+
+dyn_rust_library(
+    name = "abi_export.so",
     srcs = ["abi_export.rs"],
 )
 

--- a/test/utility.cc
+++ b/test/utility.cc
@@ -41,6 +41,17 @@ std::vector<std::string> getWasmEngines() {
   return engines;
 }
 
+std::vector<std::string> getDynEngines() {
+  std::vector<std::string> engines = {
+#if defined(PROXY_WASM_HOST_ENGINE_DYN)
+    "dyn",
+#endif
+    ""
+  };
+  engines.pop_back();
+  return engines;
+}
+
 std::string readTestWasmFile(const std::string &filename) {
   auto path = "test/test_data/" + filename;
   std::ifstream file(path, std::ios::binary);

--- a/test/utility.h
+++ b/test/utility.h
@@ -39,6 +39,9 @@
 #if defined(PROXY_WASM_HOST_ENGINE_WAMR)
 #include "include/proxy-wasm/wamr.h"
 #endif
+#if defined(PROXY_WASM_HOST_ENGINE_DYN)
+#include "include/proxy-wasm/dyn.h"
+#endif
 
 namespace proxy_wasm {
 
@@ -185,6 +188,10 @@ public:
 #if defined(PROXY_WASM_HOST_ENGINE_WAMR)
     } else if (engine == "wamr") {
       vm = proxy_wasm::createWamrVm();
+#endif
+#if defined(PROXY_WASM_HOST_ENGINE_DYN)
+    } else if (engine == "dyn") {
+      vm = proxy_wasm::createDynVm();
 #endif
     } else {
       ADD_FAILURE() << "compiled without support for the requested \"" << engine << "\" engine";


### PR DESCRIPTION
This PR adds a variant of NullVm, DynVM, that can load in native modules as dynamically linked modules.

Haven't written any automated tests yet, wanted to check if any design changes were going to be needed first, since the tests are going to be a bit more complicated than NullVM.

We've been testing this internally in an Envoy integration.