### PR TITLE
Update cargo-raze used by Format workflow to v0.16.1

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -87,7 +87,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install dependencies
-      run: cargo install cargo-raze --version 0.14.1
+      run: cargo install cargo-raze --version 0.16.1
 
     - name: Format (bazel query)
       run: |


### PR DESCRIPTION
This is to address failures in the "check format with cargo-raze" action, e.g. https://github.com/proxy-wasm/proxy-wasm-cpp-host/actions/runs/7263944116/job/19790363856