### PR TITLE
Update BoringSSL to 2023-08-28.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "@proxy_wasm_cpp_host//bazel:select.bzl",
     "proxy_wasm_select_engine_null",
@@ -22,6 +21,7 @@ load(
     "proxy_wasm_select_engine_wasmtime",
     "proxy_wasm_select_engine_wavm",
 )
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 licenses(["notice"])  # Apache 2
 

--- a/BUILD
+++ b/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "@proxy_wasm_cpp_host//bazel:select.bzl",
     "proxy_wasm_select_engine_null",
@@ -21,7 +22,6 @@ load(
     "proxy_wasm_select_engine_wasmtime",
     "proxy_wasm_select_engine_wavm",
 )
-load("@rules_cc//cc:defs.bzl", "cc_library")
 
 licenses(["notice"])  # Apache 2
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -87,10 +87,10 @@ def proxy_wasm_cpp_host_repositories():
     maybe(
         http_archive,
         name = "boringssl",
-        # 2022-02-07 (master-with-bazel)
-        sha256 = "7dec97795a7ac7e3832228e4440ee06cceb18d3663f4580b0840e685281e28a0",
-        strip_prefix = "boringssl-eaa29f431f71b8121e1da76bcd3ddc2248238ade",
-        urls = ["https://github.com/google/boringssl/archive/eaa29f431f71b8121e1da76bcd3ddc2248238ade.tar.gz"],
+        # 2023-08-28 (master-with-bazel)
+        sha256 = "f1f421738e9ba39dd88daf8cf3096ddba9c53e2b6b41b32fff5a3ff82f4cd162",
+        strip_prefix = "boringssl-45cf810dbdbd767f09f8cb0b0fcccd342c39041f",
+        urls = ["https://github.com/google/boringssl/archive/45cf810dbdbd767f09f8cb0b0fcccd342c39041f.tar.gz"],
     )
 
     maybe(


### PR DESCRIPTION
Fixes build warning-as-error:
```
external/boringssl/src/crypto/x509/t_x509.c:326:18: error: variable 'l' set but not used [-Werror,-Wunused-but-set-variable]
    int ret = 0, l, i;
                 ^
```