### PR TITLE
fix: Bump Abseil to fix Linux build issues

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -82,11 +82,14 @@ def proxy_wasm_cpp_host_repositories():
         patch_args = ["-p1"],
     )
 
-    # Core deps. Try to keep up with Envoy versions:
-    # https://github.com/envoyproxy/envoy/blob/main/bazel/repository_locations.bzl
+    # Core deps. Keep them updated.
 
-    # Note: latest LTS release, ahead of Envoy to pick up a bugfix found in local fuzzing:
-    # https://github.com/abseil/abseil-cpp/commit/e7858c73279d81cbc005d9c76a385ab535520635
+    # Note: we depend on Abseil via rules_fuzzing. Remove this pin when we update that.
+    #
+    # This is the latest LTS release, which picks up:
+    # - Build fix: https://github.com/abseil/abseil-cpp/pull/1187
+    # - A bugfix found in local fuzzing:
+    #   https://github.com/abseil/abseil-cpp/commit/e7858c73279d81cbc005d9c76a385ab535520635
     maybe(
         http_archive,
         name = "com_google_absl",

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -82,7 +82,18 @@ def proxy_wasm_cpp_host_repositories():
         patch_args = ["-p1"],
     )
 
-    # Core.
+    # Core deps. Try to keep up with Envoy versions:
+    # https://github.com/envoyproxy/envoy/blob/main/bazel/repository_locations.bzl
+
+    # Note: latest LTS release, ahead of Envoy to pick up a bugfix found in local fuzzing:
+    # https://github.com/abseil/abseil-cpp/commit/e7858c73279d81cbc005d9c76a385ab535520635
+    maybe(
+        http_archive,
+        name = "com_google_absl",
+        sha256 = "733726b8c3a6d39a4120d7e45ea8b41a434cdacde401cba500f14236c49b39dc",
+        strip_prefix = "abseil-cpp-20240116.2",
+        urls = ["https://github.com/abseil/abseil-cpp/archive/20240116.2.tar.gz"],
+    )
 
     maybe(
         http_archive,


### PR DESCRIPTION
Pick up this fix: https://github.com/abseil/abseil-cpp/pull/1187

Bump to latest LTS version (past Envoy) to pick up another fix found in local fuzz tests:
https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/399#issuecomment-2261871275

Build issue seen on:
```
$ /usr/lib/llvm-16/bin/clang --version
Debian clang version 16.0.6 (26)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm-16/bin
```