### PR TITLE
fix: Move CI from unavailable macos-11 to macos-13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,7 +176,7 @@ jobs:
         - name: 'V8 on macOS/x86_64'
           engine: 'v8'
           repo: 'v8'
-          os: macos-11
+          os: macos-13
           arch: x86_64
           action: test
           cache: true
@@ -190,7 +190,7 @@ jobs:
         - name: 'WAMR interp on macOS/x86_64'
           engine: 'wamr-interp'
           repo: 'com_github_bytecodealliance_wasm_micro_runtime'
-          os: macos-11
+          os: macos-13
           arch: x86_64
           action: test
         - name: 'WAMR jit on Linux/x86_64'
@@ -205,7 +205,7 @@ jobs:
         - name: 'WAMR jit on macOS/x86_64'
           engine: 'wamr-jit'
           repo: 'com_github_bytecodealliance_wasm_micro_runtime'
-          os: macos-11
+          os: macos-13
           arch: x86_64
           action: test
           cache: true
@@ -219,7 +219,7 @@ jobs:
         - name: 'WasmEdge on macOS/x86_64'
           engine: 'wasmedge'
           repo: 'com_github_wasmedge_wasmedge'
-          os: macos-11
+          os: macos-13
           arch: x86_64
           action: test
         - name: 'Wasmtime on Linux/x86_64'
@@ -256,7 +256,7 @@ jobs:
         - name: 'Wasmtime on macOS/x86_64'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'
-          os: macos-11
+          os: macos-13
           arch: x86_64
           action: test
         - name: 'Wasmtime on Windows/x86_64'


### PR DESCRIPTION
See: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

This does not fix #384, but does resurface those errors.