### PR TITLE
chore: bump rules_python and rules_fuzzing

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,6 +8,14 @@ load("@proxy_wasm_cpp_host//bazel:dependencies.bzl", "proxy_wasm_cpp_host_depend
 
 proxy_wasm_cpp_host_dependencies()
 
+load("@proxy_wasm_cpp_host//bazel:dependencies_python.bzl", "proxy_wasm_cpp_host_dependencies_python")
+
+proxy_wasm_cpp_host_dependencies_python()
+
+load("@proxy_wasm_cpp_host//bazel:dependencies_import.bzl", "proxy_wasm_cpp_host_dependencies_import")
+
+proxy_wasm_cpp_host_dependencies_import()
+
 load("@proxy_wasm_cpp_sdk//bazel:repositories.bzl", "proxy_wasm_cpp_sdk_repositories")
 
 proxy_wasm_cpp_sdk_repositories()

--- a/bazel/dependencies.bzl
+++ b/bazel/dependencies.bzl
@@ -16,20 +16,18 @@ load("@bazel-zig-cc//toolchain:defs.bzl", zig_register_toolchains = "register_to
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 load("@proxy_wasm_cpp_host//bazel/cargo/wasmsign/remote:crates.bzl", wasmsign_crate_repositories = "crate_repositories")
 load("@proxy_wasm_cpp_host//bazel/cargo/wasmtime/remote:crates.bzl", wasmtime_crate_repositories = "crate_repositories")
-load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
-load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
-load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
-load("@rules_python//python:pip.bzl", "pip_install")
+load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
 load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
 load("@rules_rust//rust:repositories.bzl", "rust_repositories", "rust_repository_set")
 
 def proxy_wasm_cpp_host_dependencies():
     # Bazel extensions.
 
-    rules_foreign_cc_dependencies()
-
-    rules_fuzzing_dependencies()
-    rules_fuzzing_init()
+    py_repositories()
+    python_register_toolchains(
+        name = "python_3_9",
+        python_version = "3.9",
+    )
 
     rust_repositories()
     rust_repository_set(
@@ -67,14 +65,6 @@ def proxy_wasm_cpp_host_dependencies():
     # NullVM dependencies.
 
     protobuf_deps()
-
-    # V8 dependencies.
-
-    pip_install(
-        name = "v8_python_deps",
-        extra_pip_args = ["--require-hashes"],
-        requirements = "@v8//:bazel/requirements.txt",
-    )
 
     # Wasmtime dependencies.
 

--- a/bazel/dependencies_import.bzl
+++ b/bazel/dependencies_import.bzl
@@ -1,0 +1,25 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@fuzzing_py_deps//:requirements.bzl", pip_fuzzing_dependencies = "install_deps")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+load("@v8_python_deps//:requirements.bzl", pip_v8_dependencies = "install_deps")
+
+def proxy_wasm_cpp_host_dependencies_import():
+    rules_foreign_cc_dependencies()
+    rules_fuzzing_dependencies()
+
+    pip_fuzzing_dependencies()
+    pip_v8_dependencies()

--- a/bazel/dependencies_python.bzl
+++ b/bazel/dependencies_python.bzl
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_python//python:pip.bzl", "pip_parse")
 load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
+load("@rules_python//python:pip.bzl", "pip_parse")
 
 def proxy_wasm_cpp_host_dependencies_python():
-
     # NOTE: this loads @fuzzing_py_deps via pip_parse
     rules_fuzzing_init()
 

--- a/bazel/dependencies_python.bzl
+++ b/bazel/dependencies_python.bzl
@@ -1,0 +1,28 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:pip.bzl", "pip_parse")
+load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
+
+def proxy_wasm_cpp_host_dependencies_python():
+
+    # NOTE: this loads @fuzzing_py_deps via pip_parse
+    rules_fuzzing_init()
+
+    # V8 dependencies.
+    pip_parse(
+        name = "v8_python_deps",
+        extra_pip_args = ["--require-hashes"],
+        requirements_lock = "@v8//:bazel/requirements.txt",
+    )

--- a/bazel/external/v8.patch
+++ b/bazel/external/v8.patch
@@ -1,6 +1,7 @@
 # 1. Disable pointer compression (limits the maximum number of WasmVMs).
 # 2. Don't expose Wasm C API (only Wasm C++ API).
 # 3. Fix gcc build error by disabling nonnull warning.
+# 4. Allow compiling v8 on macOS 10.15 to 13.0. TODO(dio): Will remove this patch when https://bugs.chromium.org/p/v8/issues/detail?id=13428 is fixed.
 
 diff --git a/BUILD.bazel b/BUILD.bazel
 index 4e89f90e7e..3fcb38b3f3 100644
@@ -27,6 +28,25 @@ index e957c0fad3..063627b72b 100644
                  # Use GNU dialect, because GCC doesn't allow using
                  # ##__VA_ARGS__ when in standards-conforming mode.
                  "-std=gnu++17",
+@@ -151,6 +152,18 @@ def _default_args():
+                 "-fno-integrated-as",
+             ],
+             "//conditions:default": [],
++        }) + select({
++            "@v8//bazel/config:is_macos": [
++                # The clang available on macOS catalina has a warning that isn't clean on v8 code.
++                "-Wno-range-loop-analysis",
++
++                # To supress warning on deprecated declaration on v8 code. For example:
++                # external/v8/src/base/platform/platform-darwin.cc:56:22: 'getsectdatafromheader_64'
++                # is deprecated: first deprecated in macOS 13.0.
++                # https://bugs.chromium.org/p/v8/issues/detail?id=13428.
++                "-Wno-deprecated-declarations",
++            ],
++            "//conditions:default": [],
+         }),
+         includes = ["include"],
+         linkopts = select({
 diff --git a/src/wasm/c-api.cc b/src/wasm/c-api.cc
 index 4473e205c0..65a6ec7e1d 100644
 --- a/src/wasm/c-api.cc

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -42,6 +42,14 @@ def proxy_wasm_cpp_host_repositories():
 
     maybe(
         http_archive,
+        name = "rules_cc",
+        sha256 = "2037875b9a4456dce4a79d112a8ae885bbc4aad968e6587dca6e64f3a0900cdf",
+        strip_prefix = "rules_cc-0.0.9",
+        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
+    )
+
+    maybe(
+        http_archive,
         name = "bazel_clang_tidy",
         sha256 = "6ed23cbff9423a30ef10becf57210a26d54fe198a211f4037d931c06f843c023",
         strip_prefix = "bazel_clang_tidy-c2fe98cfec0430e78bff4169e9ca0a43123e4c99",
@@ -69,17 +77,17 @@ def proxy_wasm_cpp_host_repositories():
     maybe(
         http_archive,
         name = "rules_fuzzing",
-        sha256 = "23bb074064c6f488d12044934ab1b0631e8e6898d5cf2f6bde087adb01111573",
-        strip_prefix = "rules_fuzzing-0.3.1",
-        url = "https://github.com/bazelbuild/rules_fuzzing/archive/v0.3.1.zip",
+        sha256 = "3ec0eee05b243552cc4a784b30323d088bf73cb2177ddda02c827e68981933f1",
+        strip_prefix = "rules_fuzzing-0.5.2",
+        urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v0.5.2.tar.gz"],
     )
 
     maybe(
         http_archive,
         name = "rules_python",
-        sha256 = "a30abdfc7126d497a7698c29c46ea9901c6392d6ed315171a6df5ce433aa4502",
-        strip_prefix = "rules_python-0.6.0",
-        url = "https://github.com/bazelbuild/rules_python/archive/0.6.0.tar.gz",
+        sha256 = "778aaeab3e6cfd56d681c89f5c10d7ad6bf8d2f1a72de9de55b23081b2d31618",
+        strip_prefix = "rules_python-0.34.0",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/0.34.0/rules_python-0.34.0.tar.gz",
     )
 
     maybe(


### PR DESCRIPTION
Fixes macOS CI https://github.com/proxy-wasm/proxy-wasm-cpp-host/issues/384

Upgrade rules_python (0.34.0) and rules_fuzzing (0.5.2)

This requires extracting more WORKSPACE phases:
- dependencies -- py_repositories() and toolchains
- dependencies_python() -- pip_parse module loading
- dependencies_import() -- python/fuzzing/other deps

The new structure roughly matches Envoy WORKSPACE:
- envoy_dependencies()
- envoy_dependencies_extra() -- not needed here
- envoy_python_dependencies()
- envoy_dependency_imports()