### PR TITLE
fix: Upgrade deprecated artifact upload/download handlers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
         done
 
     - name: Upload test data
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: test_data
         path: bazel-bin/test/test_data/*.wasm
@@ -306,7 +306,7 @@ jobs:
           ${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.engine }}-${{ steps.cache-key.outputs.uniq }}-
 
     - name: Download test data
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: test_data
         path: test/test_data/


### PR DESCRIPTION
Seen on https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/380 CI:

Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Fixes https://github.com/proxy-wasm/proxy-wasm-cpp-host/issues/416