### PR TITLE
Fix references to prefix_wasm_api

### DIFF
--- a/bazel/external/wasmtime.BUILD
+++ b/bazel/external/wasmtime.BUILD
@@ -21,7 +21,7 @@ genrule(
         "crates/c-api/include/wasm.h",
     ],
     outs = [
-        "include/prefixed_wasm.h",
+        "crates/c-api/include/prefixed_wasm.h",
     ],
     cmd = """
         sed -e 's/\\ wasm_/\\ wasmtime_wasm_/g' \


### PR DESCRIPTION
References to `include/wasm.h` changed to `crates/c-api/include/wasm.h`, so the prefixed api output needs to change as well. Fixes #418 