### PR TITLE
Don't pause processing when send_local_response fails

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -89,6 +89,7 @@ cc_test(
     data = [
         "//test/test_data:clock.wasm",
         "//test/test_data:env.wasm",
+        "//test/test_data:local_response.wasm",
         "//test/test_data:random.wasm",
     ],
     linkstatic = 1,

--- a/test/test_data/BUILD
+++ b/test/test_data/BUILD
@@ -80,6 +80,12 @@ wasm_rust_binary(
     wasi = True,
 )
 
+wasm_rust_binary(
+    name = "local_response.wasm",
+    srcs = ["local_response.rs"],
+    wasi = True,
+)
+
 proxy_wasm_cc_binary(
     name = "canary_check.wasm",
     srcs = ["canary_check.cc"],

--- a/test/test_data/local_response.rs
+++ b/test/test_data/local_response.rs
@@ -1,0 +1,62 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#[no_mangle]
+pub extern "C" fn proxy_abi_version_0_2_0() {}
+
+#[no_mangle]
+pub extern "C" fn proxy_on_memory_allocate(_: usize) -> *mut u8 {
+    std::ptr::null_mut()
+}
+
+fn send_http_response(status_code: u32) -> u32 {
+    let headers = 0u32.to_le_bytes().to_vec();
+    unsafe {
+        proxy_send_local_response(
+            status_code,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            headers.as_ptr(),
+            headers.len(),
+            -1)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn run_fail() {
+    println!(
+        "proxy_send_local_response returned {}",
+        send_http_response(404));
+}
+
+#[no_mangle]
+pub extern "C" fn run_success() {
+    println!(
+        "proxy_send_local_response returned {}",
+        send_http_response(200));
+}
+
+extern "C" {
+    fn proxy_send_local_response(
+        status_code: u32,
+        status_code_details_data: *const u8,
+        status_code_details_size: usize,
+        body_data: *const u8,
+        body_size: usize,
+        headers_data: *const u8,
+        headers_size: usize,
+        grpc_status: i32,
+    ) -> u32;
+}


### PR DESCRIPTION
For context see the Envoy issue https://github.com/envoyproxy/envoy/issues/28826. Here is a shorter summary:

1. A wasm plugin calls proxy_send_local_response from both onRequestHeaders and onResponseHeaders
2. When proxy_send_local_reply is called from onRequestHeaders it triggers a local reply and that reply goes through the filter chain in Envoy
3. The same plugin is called again as part of the filter chain processing but this time onResponseHeaders is called
4. onResponseHeaders calls proxy_send_local_response which ultimately does not generate a local reply, but it stops filter chain processing.

As a result we end up with a stuck connection on Envoy - no local reply and processing is stopped.

I think that proxy wasm plugins shouldn't use proxy_send_local_response this way, so ultimately whoever created such a plugin shot themselves in the foot. That being said, I think there are a few improvements that could be made here on Envoy/proxy-wasm side to handle this situation somewhat better:

1. We can avoid stopping processing in such cases to prevent stuck connections on Envoy
2. We can return errors from proxy_send_local_response instead of silently ignoring them.

Currently Envoy implementation of sendLocalResponse can detect when a second local response is requested and returns an error in this case without actually trying to send a local response.

However, even though Envoy reports an error, send_local_response ignores the result of the host specific sendLocalResponse implementation and stops processing and returns success to the wasm plugin.

With this change, send_local_response will check the result of the host-specific implementation of the sendLocalResponse. In cases when sendLocalResponse fails it will just propagate the error to the caller and do nothing else (including stopping processing).

I think this behavior makes sense in principle because on the one hand we don't ignore the failure from sendLocalResponse and on the other hand, when the failure happens we don't trigger any side-effects expected from the successful proxy_send_local_response call.

NOTE: Even though I do think that this is a more resonable behavior, it's still a change from the previous behavior and it might break existing proxy-wasm plugins. Specifically:

1. C++ plugins that proactively check the result of proxy_send_local_response will change behavior (e.g., before proxy_send_local_response failed silently)
2. Rust plugins, due to the way Rust SDK handles errors from proxy_send_local_response will crash in runtime in this case.

On the bright side of things, the plugins that are affected by this change currently just cause stuck connections in Envoy, so we are changing one undesirable behavior for another, but more explicit.


**A couple of additional notes for reviewers**:

* If there are not disagreement with the overall approach, but you don't want to change user visible beahvior when sendLocalResponse fails, I can revert to silencing the error, though it would not be my first preference;
* I created an utility function for unit tests to stringify a list of arguments, but I'm pretty sure similar functions already exist in libraries like Abseil; if reviewers will be in favor of including Abseil to the proxy-wasm-cpp-host, I can spend some time and work out how to make that happen and not break Envoy in the meantime.