### PR TITLE
add leonm1@ to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @PiotrSikora @martijneken @mpwarres
+* @PiotrSikora @martijneken @mpwarres @leonm1


### PR DESCRIPTION
Matt is on the same team as existing owners @martijneken and @mpwarres, knows the proxy-wasm-cpp-host codebase well, and having the additional owner will be helpful in reviving update velocity. 