### PR TITLE
Feat: Add "Plugin Crash" to messages logged when plugins crash within v8 to improve error observability

### DIFF
--- a/src/v8/v8.cc
+++ b/src/v8/v8.cc
@@ -106,7 +106,7 @@ public:
 private:
   wasm::own<wasm::Trap> trap(std::string message);
 
-  std::string getFailMessage(std::string_view function_name, wasm::own<wasm::Trap> trap);
+  std::string getPluginFailMessage(std::string_view function_name, wasm::own<wasm::Trap> trap);
 
   template <typename... Args>
   void registerHostFunctionImpl(std::string_view module_name, std::string_view function_name,
@@ -638,7 +638,8 @@ void V8::getModuleFunctionImpl(std::string_view function_name,
     }
 
     if (trap) {
-      fail(FailState::RuntimeError, getFailMessage(std::string(function_name), std::move(trap)));
+      fail(FailState::RuntimeError,
+           getPluginFailMessage(std::string(function_name), std::move(trap)));
       return;
     }
     if (log) {
@@ -690,7 +691,8 @@ void V8::getModuleFunctionImpl(std::string_view function_name,
     }
 
     if (trap) {
-      fail(FailState::RuntimeError, getFailMessage(std::string(function_name), std::move(trap)));
+      fail(FailState::RuntimeError,
+           getPluginFailMessage(std::string(function_name), std::move(trap)));
       return R{};
     }
     R rvalue = results[0].get<typename ConvertWordTypeToUint32<R>::type>();
@@ -708,8 +710,8 @@ void V8::terminate() {
   isolate->TerminateExecution();
 }
 
-std::string V8::getFailMessage(std::string_view function_name, wasm::own<wasm::Trap> trap) {
-  auto message = "Function: " + std::string(function_name) + " failed: ";
+std::string V8::getPluginFailMessage(std::string_view function_name, wasm::own<wasm::Trap> trap) {
+  auto message = "Plugin Crash: Function: " + std::string(function_name) + " failed: ";
   message += std::string(trap->message().get(), trap->message().size());
 
   if (function_names_index_.empty()) {


### PR DESCRIPTION
Without this change, plugin crashes are not clear to the customer in the logs. They see stack traces in Cloud Logging that just say "function: failed" (see [logs example](https://screenshot.googleplex.com/8c73FLz4ar8Y4Rx))

I also renamed the getFailMessage() function to getPluginFailMessage() in order to make it clear that this function only is called due to plugin crashes.