### PR TITLE
Chore: Remove the initEngine methods, and update Warm test.

### DIFF
--- a/include/proxy-wasm/v8.h
+++ b/include/proxy-wasm/v8.h
@@ -21,7 +21,6 @@
 
 namespace proxy_wasm {
 
-bool initV8Engine();
 std::unique_ptr<WasmVm> createV8Vm();
 
 } // namespace proxy_wasm

--- a/include/proxy-wasm/wamr.h
+++ b/include/proxy-wasm/wamr.h
@@ -21,7 +21,6 @@
 
 namespace proxy_wasm {
 
-bool initWamrEngine();
 std::unique_ptr<WasmVm> createWamrVm();
 
 } // namespace proxy_wasm

--- a/include/proxy-wasm/wasmtime.h
+++ b/include/proxy-wasm/wasmtime.h
@@ -18,7 +18,6 @@
 
 namespace proxy_wasm {
 
-bool initWasmtimeEngine();
 std::unique_ptr<WasmVm> createWasmtimeVm();
 
 } // namespace proxy_wasm

--- a/src/v8/v8.cc
+++ b/src/v8/v8.cc
@@ -755,8 +755,6 @@ std::string V8::getFailMessage(std::string_view function_name, wasm::own<wasm::T
 
 } // namespace v8
 
-bool initV8Engine() { return v8::engine() != nullptr; }
-
 std::unique_ptr<WasmVm> createV8Vm() { return std::make_unique<v8::V8>(); }
 
 } // namespace proxy_wasm

--- a/src/wamr/wamr.cc
+++ b/src/wamr/wamr.cc
@@ -713,8 +713,6 @@ void Wamr::warm() { initStore(); }
 
 } // namespace wamr
 
-bool initWamrEngine() { return wamr::engine() != nullptr; }
-
 std::unique_ptr<WasmVm> createWamrVm() { return std::make_unique<wamr::Wamr>(); }
 
 } // namespace proxy_wasm

--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -710,8 +710,6 @@ void Wasmtime::warm() { initStore(); }
 
 } // namespace wasmtime
 
-bool initWasmtimeEngine() { return wasmtime::engine() != nullptr; }
-
 std::unique_ptr<WasmVm> createWasmtimeVm() { return std::make_unique<wasmtime::Wasmtime>(); }
 
 } // namespace proxy_wasm


### PR DESCRIPTION
InitEngine is not necessary, because the warm() methods initialize the engines themselves.