### PR TITLE
chore: execute proxy-wasm-cpp-host ubuntu-24.04 actions on larger runner

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -43,7 +43,7 @@ jobs:
   addlicense:
     name: verify licenses
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-16core
 
     steps:
     - uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
   buildifier:
     name: check format with buildifier
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-16core
 
     steps:
     - uses: actions/checkout@v2
@@ -101,7 +101,7 @@ jobs:
   clang_format:
     name: check format with clang-format
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-16core
 
     steps:
     - uses: actions/checkout@v2
@@ -117,7 +117,7 @@ jobs:
   clang_tidy:
     name: check format with clang-tidy
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-16core
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
   test_data:
     name: build test data
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-16core
 
     steps:
     - uses: actions/checkout@v2
@@ -128,19 +128,19 @@ jobs:
         include:
         - name: 'NullVM on Linux/x86_64'
           engine: 'null'
-          os: ubuntu-24.04
+          os: ubuntu-24.04-16core
           arch: x86_64
           action: test
           flags: --config=gcc
         - name: 'NullVM on Linux/x86_64 with ASan'
           engine: 'null'
-          os: ubuntu-24.04
+          os: ubuntu-24.04-16core
           arch: x86_64
           action: test
           flags: --config=clang-asan --define=crypto=system
         - name: 'NullVM on Linux/x86_64 with TSan'
           engine: 'null'
-          os: ubuntu-24.04
+          os: ubuntu-24.04-16core
           arch: x86_64
           action: test
           flags: --config=clang-tsan
@@ -153,7 +153,7 @@ jobs:
         - name: 'V8 on Linux/x86_64'
           engine: 'v8'
           repo: 'v8'
-          os: ubuntu-24.04
+          os: ubuntu-24.04-16core
           arch: x86_64
           action: test
           flags: --config=hermetic-llvm --define=crypto=system
@@ -161,7 +161,7 @@ jobs:
         - name: 'V8 on Linux/x86_64 with ASan'
           engine: 'v8'
           repo: 'v8'
-          os: ubuntu-24.04
+          os: ubuntu-24.04-16core
           arch: x86_64
           action: test
           flags: --config=hermetic-llvm --config=clang-asan
@@ -169,7 +169,7 @@ jobs:
         - name: 'V8 on Linux/x86_64 with TSan'
           engine: 'v8'
           repo: 'v8'
-          os: ubuntu-24.04
+          os: ubuntu-24.04-16core
           arch: x86_64
           action: test
           flags: --config=hermetic-llvm --config=clang-tsan
@@ -177,7 +177,7 @@ jobs:
         - name: 'V8 on Linux/x86_64 with GCC'
           engine: 'v8'
           repo: 'v8'
-          os: ubuntu-24.04
+          os: ubuntu-24.04-16core
           arch: x86_64
           action: test
           flags: --config=gcc
@@ -202,7 +202,7 @@ jobs:
         - name: 'WAMR interp on Linux/x86_64'
           engine: 'wamr-interp'
           repo: 'com_github_bytecodealliance_wasm_micro_runtime'
-          os: ubuntu-24.04
+          os: ubuntu-24.04-16core
           arch: x86_64
           action: test
           flags: --config=clang
@@ -215,7 +215,7 @@ jobs:
         - name: 'WAMR jit on Linux/x86_64'
           engine: 'wamr-jit'
           repo: 'com_github_bytecodealliance_wasm_micro_runtime'
-          os: ubuntu-24.04
+          os: ubuntu-24.04-16core
           arch: x86_64
           action: test
           flags: --config=clang
@@ -231,7 +231,7 @@ jobs:
         - name: 'WasmEdge on Linux/x86_64'
           engine: 'wasmedge'
           repo: 'com_github_wasmedge_wasmedge'
-          os: ubuntu-24.04
+          os: ubuntu-24.04-16core
           arch: x86_64
           action: test
           flags: --config=clang
@@ -244,14 +244,14 @@ jobs:
         - name: 'Wasmtime on Linux/x86_64'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'
-          os: ubuntu-24.04
+          os: ubuntu-24.04-16core
           arch: x86_64
           action: test
           flags: --config=clang -c opt
         - name: 'Wasmtime on Linux/x86_64 with ASan'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'
-          os: ubuntu-24.04
+          os: ubuntu-24.04-16core
           arch: x86_64
           action: test
           flags: --config=clang-asan --define=crypto=system
@@ -265,7 +265,7 @@ jobs:
         - name: 'Wasmtime on Linux/s390x'
           engine: 'wasmtime'
           repo: 'com_github_bytecodealliance_wasmtime'
-          os: ubuntu-24.04
+          os: ubuntu-24.04-16core
           arch: s390x
           action: test
           flags: --config=clang --test_timeout=1800


### PR DESCRIPTION
Modify proxy-wasm-cpp-host Github actions that previously ran on stock ubuntu-24.04 runner to instead use a newly provisioned larger runner instance, with 16 cores, 64GB RAM, and 600GB SSD.

Should fix #457.