### PR TITLE
Feat: Allow invocation of the emscripten_notify_memory_growth hostcall.

### DIFF
--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -378,8 +378,7 @@ ContextBase *WasmBase::getRootContext(const std::shared_ptr<PluginBase> &plugin,
 void WasmBase::startVm(ContextBase *root_context) {
   // wasi_snapshot_preview1.clock_time_get
   wasm_vm_->setRestrictedCallback(
-      true, {
-             // emscripten
+      true, {// emscripten
              "env.emscripten_notify_memory_growth",
              // logging (Proxy-Wasm)
              "env.proxy_log",


### PR DESCRIPTION
The emscripten_notify_memory_growth function is invoked by emscripten when it grows the heap. Allowlisting this function is needed in order to make use of a smaller emscripten INITIAL_HEAP setting