### PR TITLE
feat: add GitHub Actions workflow for publishing Build Tools Docker image

### DIFF
--- a/.github/workflows/publish-build-tools.yml
+++ b/.github/workflows/publish-build-tools.yml
@@ -1,0 +1,79 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish Build Tools Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      ubuntu_version:
+        description: 'Ubuntu version for base image'
+        required: true
+      bazel_version:
+        description: 'Bazel version to build'
+        required: true
+      platforms:
+        description: 'Target platforms (comma-separated)'
+        required: false
+        default: 'linux/s390x'
+      draft:
+        description: 'Draft mode (true: build only, false: build and push)'
+        type: boolean
+        required: false
+        default: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04-16core
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Generate tag
+      id: tag
+      run: |
+        TAG="ubuntu-${{ github.event.inputs.ubuntu_version }}-bazel-${{ github.event.inputs.bazel_version }}"
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+    - name: Login to GitHub Container Registry
+      if: ${{ !github.event.inputs.draft }}
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and Push Docker Image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: bazel/external/Dockerfile.bazel
+        platforms: ${{ github.event.inputs.platforms }}
+        tags: ghcr.io/proxy-wasm/build-tools:${{ steps.tag.outputs.tag }}
+        build-args: |
+          UBUNTU_VERSION=${{ github.event.inputs.ubuntu_version }}
+          BAZEL_VERSION=${{ github.event.inputs.bazel_version }}
+        push: ${{ !github.event.inputs.draft }}
+        load: ${{ github.event.inputs.draft }}
+        cache-from: type=gha,scope=build-tools-${{ steps.tag.outputs.tag }}
+        cache-to: type=gha,mode=max,scope=build-tools-${{ steps.tag.outputs.tag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -277,7 +277,7 @@ jobs:
 
     - name: Activate Docker/QEMU
       if: startsWith(matrix.run_under, 'docker')
-      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
       if: startsWith(matrix.run_under, 'docker')

--- a/bazel/external/Dockerfile.bazel
+++ b/bazel/external/Dockerfile.bazel
@@ -14,24 +14,75 @@
 # limitations under the License.
 
 
-# Prep:
-#   docker run --rm --privileged tonistiigi/binfmt --install all
-#   docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-#   Need to see "F" flag: cat /proc/sys/fs/binfmt_misc/qemu-*
+# ============================================================================
+# BUILD TOOLS DOCKER IMAGE WORKFLOWS
+# ============================================================================
 #
-# Build:
-#   docker buildx build --platform linux/s390x -t $IMAGE -f Dockerfile.bazel
+# This Dockerfile creates build tools images for cross-platform testing,
+# particularly for s390x architecture. Images are published to GitHub
+# Container Registry (ghcr.io/proxy-wasm/build-tools).
 #
-# Push:
-#   docker image tag $IMAGE ghcr.io/proxy-wasm/$IMAGE
-#   docker push ghcr.io/proxy-wasm/$IMAGE
+# ----------------------------------------------------------------------------
+# RECOMMENDED: Automated Workflow (via GitHub Actions)
+# ----------------------------------------------------------------------------
 #
-# Test:
-#   docker run --rm --volume $(pwd):/mnt --workdir /mnt \
-#     --platform linux/s390x $IMAGE \
-#     bazel test --verbose_failures --test_output=errors \
-#     --define engine=null --config=clang --test_timeout=1800 \
-#     -- //test/...
+# The preferred method for publishing build tools images is through the
+# automated GitHub Actions workflow defined in:
+#   .github/workflows/publish-build-tools.yml
+#
+# This workflow can be triggered manually via the GitHub UI:
+#   1. Go to Actions tab in the repository
+#   2. Select "Publish Build Tools Docker Image"
+#   3. Click "Run workflow"
+#   4. Provide the required inputs:
+#      - ubuntu_version: Base Ubuntu version (e.g., 22.04, 24.04)
+#      - bazel_version: Bazel version to build (e.g., 6.5.0, 7.0.0)
+#      - platforms: Target platforms (default: linux/s390x)
+#      - draft: Set to 'false' to build and push, 'true' for build-only testing
+#
+# The workflow handles QEMU setup, multi-platform builds, caching, and
+# authentication automatically. Images are tagged as:
+#   ghcr.io/proxy-wasm/build-tools:ubuntu-{VERSION}-bazel-{VERSION}
+#
+# This automated approach is recommended because it:
+#   - Ensures consistent build environments
+#   - Handles authentication and permissions automatically
+#   - Provides build caching for faster iterations
+#   - Supports draft mode for testing before publishing
+#
+# ----------------------------------------------------------------------------
+# ALTERNATIVE: Manual Build and Push
+# ----------------------------------------------------------------------------
+#
+# For local development or when automated workflows are unavailable,
+# you can manually build and push images using the following steps:
+#
+# 1. Prep (enable cross-platform emulation):
+#      docker run --rm --privileged tonistiigi/binfmt --install all
+#      docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+#      # Verify "F" flag: cat /proc/sys/fs/binfmt_misc/qemu-*
+#
+# 2. Build:
+#      docker buildx build --platform linux/s390x \
+#        --build-arg UBUNTU_VERSION=22.04 \
+#        --build-arg BAZEL_VERSION=6.5.0 \
+#        -t build-tools:local \
+#        -f bazel/external/Dockerfile.bazel .
+#
+# 3. Push (requires appropriate permissions):
+#      docker image tag build-tools:local \
+#        ghcr.io/proxy-wasm/build-tools:ubuntu-22.04-bazel-6.5.0
+#      docker push ghcr.io/proxy-wasm/build-tools:ubuntu-22.04-bazel-6.5.0
+#
+# 4. Test:
+#      docker run --rm --volume $(pwd):/mnt --workdir /mnt \
+#        --platform linux/s390x \
+#        ghcr.io/proxy-wasm/build-tools:ubuntu-22.04-bazel-6.5.0 \
+#        bazel test --verbose_failures --test_output=errors \
+#        --define engine=null --config=clang --test_timeout=1800 \
+#        -- //test/...
+#
+# ============================================================================
 
 ARG BAZEL_VERSION=7.7.1
 ARG UBUNTU_VERSION=24.04


### PR DESCRIPTION
#### Description


Provide a way to draft or push ghcr.io/proxy-wasm/build-tools

It also align the way QEMU is setup between the run and build workflow 