### PR TITLE
Disable external cache in Bazel setup for format workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -92,7 +92,7 @@ jobs:
       with:
         bazelisk-cache: true
         disk-cache: ${{ github.job }}
-        external-cache: true
+        external-cache: false
         repository-cache: true
 
     - name: Format (bazel query)
@@ -133,7 +133,7 @@ jobs:
       with:
         bazelisk-cache: true
         disk-cache: ${{ github.job }}
-        external-cache: true
+        external-cache: false
         repository-cache: true
 
     - name: Bazel build


### PR DESCRIPTION
#### Description 

Disable external cache in Bazel setup for format workflows.