### PR TITLE
ci: use bigger runner for rules_rust execution

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -83,7 +83,7 @@ jobs:
   rules_rust:
     name: check format with rules_rust
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Will hopefully fix the ongoing CI failures in executing rules_rust.