### PR TITLE
Use V8's Starlark transition API instead of patching pointer compression default

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -134,7 +134,7 @@ cc_library(
     ],
     deps = [
         ":wasm_vm_headers",
-        "@v8//:wee8",
+        "//bazel:wee8_no_pointer_compression",
     ],
 )
 

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//lib:selects.bzl", "selects")
+load(":v8_transition.bzl", "v8_lib_no_pointer_compression")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -67,6 +68,13 @@ selects.config_setting_group(
         ":requested_crypto_system",
         ":linux_s390x",
     ],
+)
+
+# V8 library with pointer compression disabled using V8's Starlark transition.
+# This avoids the need to patch V8's default pointer compression setting.
+v8_lib_no_pointer_compression(
+    name = "wee8_no_pointer_compression",
+    library = "@v8//:wee8",
 )
 
 exports_files(["tsan_suppressions.txt"])

--- a/bazel/external/v8.patch
+++ b/bazel/external/v8.patch
@@ -1,36 +1,7 @@
-From 3b6a69271801db1b1a411fb969b515c74c459f65 Mon Sep 17 00:00:00 2001
-From: Matt Leon <mattleon@google.com>
-Date: Wed, 16 Jul 2025 16:55:02 -0400
-Subject: [PATCH 1/7] Disable pointer compression
-
-Pointer compression limits the maximum number of WasmVMs.
-
-Signed-off-by: Matt Leon <mattleon@google.com>
----
- BUILD.bazel | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/BUILD.bazel b/BUILD.bazel
-index b1a54b2b42c..96c8be8901f 100644
---- a/BUILD.bazel
-+++ b/BUILD.bazel
-@@ -296,7 +296,7 @@ v8_int(
- # If no explicit value for v8_enable_pointer_compression, we set it to 'none'.
- v8_string(
-     name = "v8_enable_pointer_compression",
--    default = "none",
-+    default = "False",
- )
- 
- # Default setting for v8_enable_pointer_compression.
--- 
-2.52.0.457.g6b5491de43-goog
-
-
 From aea5afcb03b19af37ed1c04cfdf294e9f4499f6b Mon Sep 17 00:00:00 2001
 From: Matt Leon <mattleon@google.com>
 Date: Wed, 16 Jul 2025 16:56:31 -0400
-Subject: [PATCH 2/7] Restore _allowlist_function_transition
+Subject: [PATCH 1/6] Restore _allowlist_function_transition
 
 Reverts v8 commit b26554ec368e9553782012c96aa5e99b163eaff2, which removed use of
 _allowlist_function_transition from v8 bazel/defs.bzl, since it is still required
@@ -85,7 +56,7 @@ index 8c929454840..57336154cf7 100644
 From 920ef0496317a512083a09caa905fbf87a01c14b Mon Sep 17 00:00:00 2001
 From: Matt Leon <mattleon@google.com>
 Date: Wed, 16 Jul 2025 16:56:52 -0400
-Subject: [PATCH 3/7] Don't expose Wasm C API (only Wasm C++ API).
+Subject: [PATCH 2/6] Don't expose Wasm C API (only Wasm C++ API).
 
 Signed-off-by: Matt Leon <mattleon@google.com>
 ---
@@ -118,7 +89,7 @@ index e7cf656ade4..660ed06021d 100644
 From f6379d9391b775f0459c3740302e435421a942c1 Mon Sep 17 00:00:00 2001
 From: Matt Leon <mattleon@google.com>
 Date: Wed, 16 Jul 2025 16:58:02 -0400
-Subject: [PATCH 4/7] Stub out fast_float for bazel-supplied version
+Subject: [PATCH 3/6] Stub out fast_float for bazel-supplied version
 
 Signed-off-by: Matt Leon <mattleon@google.com>
 ---
@@ -145,7 +116,7 @@ index 96c8be8901f..05630ab7035 100644
 From 98a46e051afa5186a07400c53923367b9bea0ebe Mon Sep 17 00:00:00 2001
 From: Matt Leon <mattleon@google.com>
 Date: Wed, 16 Jul 2025 20:04:05 -0400
-Subject: [PATCH 5/7] Stub out vendored dependencies for bazel-sourced versions
+Subject: [PATCH 4/6] Stub out vendored dependencies for bazel-sourced versions
 
 Signed-off-by: Matt Leon <mattleon@google.com>
 ---
@@ -177,7 +148,7 @@ index 05630ab7035..7f14a987148 100644
 From e3cebe8ca694935302a8c3806ab6398c593f31cd Mon Sep 17 00:00:00 2001
 From: Matt Leon <mattleon@google.com>
 Date: Wed, 16 Jul 2025 20:29:10 -0400
-Subject: [PATCH 6/7] Add build flags to make V8 compile with GCC
+Subject: [PATCH 5/6] Add build flags to make V8 compile with GCC
 
 Signed-off-by: Matt Leon <mattleon@google.com>
 ---
@@ -205,7 +176,7 @@ index ba8315bb938..277a07ef63d 100644
 From 5f9cd8cf1b1758678d41f96cd22477e052c787f8 Mon Sep 17 00:00:00 2001
 From: Matt Leon <mattleon@google.com>
 Date: Fri, 18 Jul 2025 17:28:42 -0400
-Subject: [PATCH 7/7] Hack out atomic simd support in V8.
+Subject: [PATCH 6/6] Hack out atomic simd support in V8.
 
 Atomic simdutf requires __cpp_lib_atomic_ref >= 201806, which is only
 supported in clang libc++ 19+. The version of LLVM used in Envoy as of

--- a/bazel/v8_transition.bzl
+++ b/bazel/v8_transition.bzl
@@ -1,0 +1,56 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wrapper rule to apply V8's pointer compression transition to cc_library targets.
+
+V8 provides v8_disable_pointer_compression transition and v8_binary_non_pointer_compression
+for cc_binary targets. This file provides the equivalent for cc_library targets by wrapping
+the same transition that V8 uses.
+"""
+
+load("@v8//:bazel/v8-non-pointer-compression.bzl", "v8_disable_pointer_compression")
+
+def _v8_lib_no_pointer_compression_impl(ctx):
+    """Forward providers from the library built with pointer compression disabled.
+
+    This is analogous to V8's _v8_binary_non_pointer_compression implementation,
+    but for cc_library instead of cc_binary.
+    """
+
+    # The transition may create a list of configured targets, take the first one
+    library = ctx.attr.library[0] if type(ctx.attr.library) == type([]) else ctx.attr.library
+    return [library[CcInfo], library[DefaultInfo]]
+
+v8_lib_no_pointer_compression = rule(
+    implementation = _v8_lib_no_pointer_compression_impl,
+    attrs = {
+        "library": attr.label(
+            cfg = v8_disable_pointer_compression,
+            providers = [CcInfo],
+            doc = "The V8 library to build with pointer compression disabled",
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    provides = [CcInfo, DefaultInfo],
+    doc = """Wraps a cc_library target with V8's pointer compression disabled.
+
+    This rule uses V8's v8_disable_pointer_compression transition (the same one used
+    by v8_binary_non_pointer_compression) to ensure v8_enable_pointer_compression
+    is set to False for the library and all its dependencies.
+
+    This is the library equivalent of V8's v8_binary_non_pointer_compression rule.
+    """,
+)


### PR DESCRIPTION
#### Description

Use V8's Starlark transition API instead of patching pointer compression default

Closes #446

