### PR TITLE
Implement execution limits for wasmtime

### DIFF
--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -16,6 +16,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -56,7 +57,11 @@ using ::wasmtime::Table;
 using ::wasmtime::TrapResult;
 
 Engine *engine() {
-  static auto *const engine = []() { return new Engine(Config{}); }();
+  static auto *const engine = []() {
+    Config config;
+    config.epoch_interruption(true);
+    return new Engine(std::move(config));
+  }();
   return engine;
 }
 
@@ -121,7 +126,7 @@ public:
 
   void warm() override;
 
-  void terminate() override {}
+  void terminate() override { engine()->increment_epoch(); }
 
   bool usesWasmByteOrder() override { return true; }
 
@@ -160,6 +165,11 @@ void Wasmtime::initStore() {
     return;
   }
   store_.emplace(*engine());
+  store_->limiter(PROXY_WASM_HOST_MAX_WASM_MEMORY_SIZE_BYTES,
+                  /*table_elements=*/std::numeric_limits<int64_t>::max(),
+                  /*instances=*/std::numeric_limits<int64_t>::max(),
+                  /*tables=*/std::numeric_limits<int64_t>::max(),
+                  /*memories=*/std::numeric_limits<int64_t>::max());
 }
 
 bool Wasmtime::load(std::string_view bytecode, std::string_view /*precompiled*/,
@@ -354,6 +364,7 @@ void Wasmtime::getModuleFunctionImpl(std::string_view function_name,
                            ")");
     }
     InPlaceConvertHostToWasmEndianness(args...);
+    store_->context().set_epoch_deadline(1);
     TrapResult<std::monostate> result = func.call(store_->context(), {args...});
     if (!result) {
       fail(FailState::RuntimeError,
@@ -387,6 +398,7 @@ void Wasmtime::getModuleFunctionImpl(std::string_view function_name,
                            ")");
     }
     InPlaceConvertHostToWasmEndianness(args...);
+    store_->context().set_epoch_deadline(1);
     TrapResult<R> result_wasm = func.call(store_->context(), {args...});
     if (!result_wasm) {
       fail(FailState::RuntimeError,

--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -166,10 +166,10 @@ void Wasmtime::initStore() {
   }
   store_.emplace(*engine());
   store_->limiter(PROXY_WASM_HOST_MAX_WASM_MEMORY_SIZE_BYTES,
-                  /*table_elements=*/std::numeric_limits<int64_t>::max(),
-                  /*instances=*/std::numeric_limits<int64_t>::max(),
-                  /*tables=*/std::numeric_limits<int64_t>::max(),
-                  /*memories=*/std::numeric_limits<int64_t>::max());
+                  /*table_elements=*/10000,
+                  /*instances=*/1,
+                  /*tables=*/10000,
+                  /*memories=*/1);
 }
 
 bool Wasmtime::load(std::string_view bytecode, std::string_view /*precompiled*/,

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -78,7 +78,7 @@ TEST_P(TestVm, StraceLogLevel) {
 
 TEST_P(TestVm, TerminateExecution) {
   // TODO(chaoqin-li1123): implement execution termination for other runtime.
-  if (engine_ != "v8") {
+  if (engine_ != "v8" && engine_ != "wasmtime") {
     return;
   }
   auto source = readTestWasmFile("resource_limits.wasm");
@@ -102,12 +102,16 @@ TEST_P(TestVm, TerminateExecution) {
   // Check integration logs.
   auto *host = dynamic_cast<TestIntegration *>(wasm.wasm_vm()->integration().get());
   EXPECT_TRUE(host->isErrorLogged("Function: infinite_loop failed"));
-  EXPECT_TRUE(host->isErrorLogged("TerminationException"));
+  if (engine_ == "v8") {
+    EXPECT_TRUE(host->isErrorLogged("TerminationException"));
+  } else if (engine_ == "wasmtime") {
+    EXPECT_TRUE(host->isErrorLogged("wasm trap: interrupt"));
+  }
 }
 
 TEST_P(TestVm, WasmMemoryLimit) {
   // TODO(PiotrSikora): enforce memory limits in other engines.
-  if (engine_ != "v8") {
+  if (engine_ != "v8" && engine_ != "wasmtime") {
     return;
   }
   auto source = readTestWasmFile("resource_limits.wasm");


### PR DESCRIPTION
Implements execution termination (with [wasmtime epochs](https://docs.wasmtime.dev/examples-interrupting-wasm.html)) as well as memory limits.

Based off of #503.