### PR TITLE
add all wasi hostcalls used by Go SDK

### DIFF
--- a/include/proxy-wasm/exports.h
+++ b/include/proxy-wasm/exports.h
@@ -133,6 +133,7 @@ Word wasi_unstable_path_open(Word fd, Word dir_flags, Word path, Word path_len, 
                              int64_t fs_rights_base, int64_t fg_rights_inheriting, Word fd_flags,
                              Word nwritten_ptr);
 Word wasi_unstable_fd_prestat_get(Word fd, Word buf_ptr);
+Word wasi_unstable_fd_filestat_get(Word fd, Word buf_ptr);
 Word wasi_unstable_fd_prestat_dir_name(Word fd, Word path_ptr, Word path_len);
 Word wasi_unstable_fd_write(Word fd, Word iovs, Word iovs_len, Word nwritten_ptr);
 Word wasi_unstable_fd_read(Word, Word, Word, Word);
@@ -148,9 +149,35 @@ Word wasi_unstable_sched_yield();
 Word wasi_unstable_poll_oneoff(Word in, Word out, Word nsubscriptions, Word nevents);
 void wasi_unstable_proc_exit(Word);
 Word wasi_unstable_clock_time_get(Word, uint64_t, Word);
+Word wasi_unstable_clock_res_get(Word, Word);
+Word wasi_unstable_fd_advise(Word, uint64_t, uint64_t, Word);
+Word wasi_unstable_fd_allocate(Word, uint64_t, uint64_t);
+Word wasi_unstable_fd_datasync(Word);
+Word wasi_unstable_fd_fdstat_set_rights(Word, uint64_t, uint64_t);
+Word wasi_unstable_fd_filestat_set_size(Word, uint64_t);
+Word wasi_unstable_fd_filestat_set_times(Word, uint64_t, uint64_t, Word);
+Word wasi_unstable_fd_pread(Word, Word, Word, uint64_t, Word);
+Word wasi_unstable_fd_pwrite(Word, Word, Word, uint64_t, Word);
+Word wasi_unstable_fd_readdir(Word, Word, Word, uint64_t, Word);
+Word wasi_unstable_fd_renumber(Word, Word);
+Word wasi_unstable_fd_sync(Word);
+Word wasi_unstable_fd_tell(Word, Word);
+Word wasi_unstable_path_create_directory(Word, Word, Word);
+Word wasi_unstable_path_filestat_set_times(Word, Word, Word, Word, uint64_t, uint64_t, Word);
+Word wasi_unstable_path_link(Word, Word, Word, Word, Word, Word);
+Word wasi_unstable_path_readlink(Word, Word, Word, Word, Word, Word);
+Word wasi_unstable_path_remove_directory(Word, Word, Word);
+Word wasi_unstable_path_rename(Word, Word, Word, Word, Word, Word);
+Word wasi_unstable_path_symlink(Word, Word, Word, Word);
+Word wasi_unstable_path_unlink_file(Word, Word, Word);
+Word wasi_unstable_sock_accept(Word, Word, Word);
+Word wasi_unstable_sock_recv(Word, Word, Word, Word, Word, Word);
+Word wasi_unstable_sock_send(Word, Word, Word, Word, Word);
+Word wasi_unstable_sock_shutdown(Word, Word);
 Word wasi_unstable_random_get(Word, Word);
 Word pthread_equal(Word left, Word right);
 void emscripten_notify_memory_growth(Word);
+Word wasi_unstable_path_filestat_get(Word fd, Word flags, Word path, Word path_len, Word buf);
 
 // Support for embedders, not exported to Wasm.
 
@@ -174,9 +201,17 @@ void emscripten_notify_memory_growth(Word);
 
 #define FOR_ALL_WASI_FUNCTIONS(_f)                                                                 \
   _f(fd_write) _f(fd_read) _f(fd_seek) _f(fd_close) _f(fd_fdstat_get) _f(fd_fdstat_set_flags)      \
-      _f(environ_get) _f(environ_sizes_get) _f(args_get) _f(args_sizes_get) _f(clock_time_get)     \
-          _f(random_get) _f(sched_yield) _f(poll_oneoff) _f(proc_exit) _f(path_open)               \
-              _f(fd_prestat_get) _f(fd_prestat_dir_name)
+      _f(fd_fdstat_set_rights) _f(environ_get) _f(environ_sizes_get) _f(args_get)                  \
+          _f(args_sizes_get) _f(clock_time_get) _f(clock_res_get) _f(fd_advise) _f(fd_allocate)    \
+              _f(fd_datasync) _f(fd_filestat_set_size) _f(fd_filestat_set_times) _f(fd_pread)      \
+                  _f(fd_pwrite) _f(fd_readdir) _f(fd_renumber) _f(fd_sync) _f(fd_tell)             \
+                      _f(path_create_directory) _f(path_filestat_set_times) _f(path_link)          \
+                          _f(path_readlink) _f(path_remove_directory) _f(path_rename)              \
+                              _f(path_symlink) _f(path_unlink_file) _f(sock_accept) _f(sock_recv)  \
+                                  _f(sock_send) _f(sock_shutdown) _f(random_get) _f(sched_yield)   \
+                                      _f(poll_oneoff) _f(proc_exit) _f(path_open)                  \
+                                          _f(fd_prestat_get) _f(fd_prestat_dir_name)               \
+                                              _f(path_filestat_get) _f(fd_filestat_get)
 
 // Helpers to generate a stub to pass to VM, in place of a restricted proxy-wasm capability.
 #define _CREATE_PROXY_WASM_STUB(_fn)                                                               \

--- a/include/proxy-wasm/wasm.h
+++ b/include/proxy-wasm/wasm.h
@@ -400,7 +400,9 @@ inline void *WasmBase::allocMemory(uint64_t size, uint64_t *address) {
              // logging (stdout/stderr)
              "wasi_unstable.fd_write", "wasi_snapshot_preview1.fd_write",
              // time
-             "wasi_unstable.clock_time_get", "wasi_snapshot_preview1.clock_time_get"});
+             "wasi_unstable.clock_time_get", "wasi_snapshot_preview1.clock_time_get",
+             // go runtime gc sleep
+             "wasi_unstable.poll_oneoff", "wasi_snapshot_preview1.poll_oneoff"});
   Word a = malloc_(vm_context(), size);
   wasm_vm_->setRestrictedCallback(false);
   if (!a.u64_) {

--- a/include/proxy-wasm/wasm_vm.h
+++ b/include/proxy-wasm/wasm_vm.h
@@ -123,23 +123,31 @@ using WasmCallback_WWmW = Word (*)(Word, uint64_t, Word);
 using WasmCallback_WWWWWWllWW = Word (*)(Word, Word, Word, Word, Word, int64_t, int64_t, Word,
                                          Word);
 using WasmCallback_dd = double (*)(double);
+// Additional callback types for new WASI functions
+using WasmCallback_WWWWmm = Word (*)(Word, Word, Word, Word, uint64_t, uint64_t);
+using WasmCallback_WWWWmmW = Word (*)(Word, Word, Word, Word, uint64_t, uint64_t, Word);
+using WasmCallback_WWmm = Word (*)(Word, uint64_t, uint64_t);
+using WasmCallback_WWmmW = Word (*)(Word, uint64_t, uint64_t, Word);
+using WasmCallback_WWWWmW = Word (*)(Word, Word, Word, uint64_t, Word);
 
 #define FOR_ALL_WASM_VM_IMPORTS(_f)                                                                \
   _f(proxy_wasm::WasmCallbackVoid<0>) _f(proxy_wasm::WasmCallbackVoid<1>)                          \
       _f(proxy_wasm::WasmCallbackVoid<2>) _f(proxy_wasm::WasmCallbackVoid<3>)                      \
           _f(proxy_wasm::WasmCallbackVoid<4>) _f(proxy_wasm::WasmCallbackWord<0>)                  \
               _f(proxy_wasm::WasmCallbackWord<1>) _f(proxy_wasm::WasmCallbackWord<2>)              \
-                  _f(proxy_wasm::WasmCallbackWord<3>) _f(proxy_wasm::WasmCallbackWord<4>)          \
-                      _f(proxy_wasm::WasmCallbackWord<5>) _f(proxy_wasm::WasmCallbackWord<6>)      \
-                          _f(proxy_wasm::WasmCallbackWord<7>) _f(proxy_wasm::WasmCallbackWord<8>)  \
-                              _f(proxy_wasm::WasmCallbackWord<9>)                                  \
-                                  _f(proxy_wasm::WasmCallbackWord<10>)                             \
-                                      _f(proxy_wasm::WasmCallbackWord<12>)                         \
-                                          _f(proxy_wasm::WasmCallback_WWl)                         \
-                                              _f(proxy_wasm::WasmCallback_WWlWW)                   \
-                                                  _f(proxy_wasm::WasmCallback_WWm)                 \
-                                                      _f(proxy_wasm::WasmCallback_WWmW)            \
-                                                          _f(proxy_wasm::WasmCallback_WWWWWWllWW)  \
+                  _f(proxy_wasm::WasmCallbackWord<3>) _f(proxy_wasm::WasmCallbackWord<4>) _f(      \
+                      proxy_wasm::WasmCallbackWord<5>) _f(proxy_wasm::WasmCallbackWord<6>)         \
+                      _f(proxy_wasm::WasmCallbackWord<7>) _f(proxy_wasm::WasmCallbackWord<8>) _f(  \
+                          proxy_wasm::WasmCallbackWord<9>) _f(proxy_wasm::WasmCallbackWord<10>)    \
+                          _f(proxy_wasm::WasmCallbackWord<12>) _f(proxy_wasm::WasmCallback_WWl)    \
+                              _f(proxy_wasm::WasmCallback_WWlWW) _f(proxy_wasm::WasmCallback_WWm)  \
+                                  _f(proxy_wasm::WasmCallback_WWmW)                                \
+                                      _f(proxy_wasm::WasmCallback_WWWWWWllWW)                      \
+                                          _f(proxy_wasm::WasmCallback_WWWWmm)                      \
+                                              _f(proxy_wasm::WasmCallback_WWWWmmW)                 \
+                                                  _f(proxy_wasm::WasmCallback_WWmm)                \
+                                                      _f(proxy_wasm::WasmCallback_WWmmW)           \
+                                                          _f(proxy_wasm::WasmCallback_WWWWmW)      \
                                                               _f(proxy_wasm::WasmCallback_dd)
 
 enum class Cloneable {

--- a/include/proxy-wasm/wasm_vm.h
+++ b/include/proxy-wasm/wasm_vm.h
@@ -123,7 +123,7 @@ using WasmCallback_WWmW = Word (*)(Word, uint64_t, Word);
 using WasmCallback_WWWWWWllWW = Word (*)(Word, Word, Word, Word, Word, int64_t, int64_t, Word,
                                          Word);
 using WasmCallback_dd = double (*)(double);
-// Additional callback types for new WASI functions
+// Additional callback types for WASIp1 functions
 using WasmCallback_WWWWmm = Word (*)(Word, Word, Word, Word, uint64_t, uint64_t);
 using WasmCallback_WWWWmmW = Word (*)(Word, Word, Word, Word, uint64_t, uint64_t, Word);
 using WasmCallback_WWmm = Word (*)(Word, uint64_t, uint64_t);

--- a/src/exports.cc
+++ b/src/exports.cc
@@ -1106,7 +1106,7 @@ Word wasi_unstable_fd_tell(Word fd, Word retptr0) {
   }
 
   // For stdout and stderr, we'll just return 0 as the offset
-  if (!context->wasm()->setDatatype(retptr0, uint64_t(0))) {
+  if (!context->wasm()->setDatatype(retptr0, 0UL)) {
     return 21; // __WASI_EFAULT
   }
 
@@ -1200,7 +1200,7 @@ Word wasi_unstable_sock_accept(Word fd, Word flags, Word retptr0) {
   // Since we don't have socket support in proxy-wasm, we can just return an error.
 
   // Set the returned file descriptor to an invalid value
-  if (!context->wasm()->setDatatype(retptr0, uint32_t(0))) {
+  if (!context->wasm()->setDatatype(retptr0, 0UL)) {
     return 21; // __WASI_EFAULT
   }
 
@@ -1222,7 +1222,7 @@ Word wasi_unstable_sock_recv(Word fd, Word ri_data_ptr, Word ri_data_len, Word r
   }
 
   // Set the output flags to 0
-  if (!context->wasm()->setDatatype(retptr1, uint16_t(0))) {
+  if (!context->wasm()->setDatatype(retptr1, static_cast<uint16_t>(0))) {
     return 21; // __WASI_EFAULT
   }
 

--- a/src/exports.cc
+++ b/src/exports.cc
@@ -913,11 +913,8 @@ Word wasi_unstable_clock_res_get(Word clock_id, Word result_resolution_uint64_pt
 Word wasi_unstable_fd_advise(Word fd, uint64_t offset, uint64_t len, Word advice) {
   // fd_advise is used to provide advice about the expected behavior of the application with respect
   // to a file. Since we don't have a real file system in proxy-wasm, we can just return success
-  // without doing anything. This is similar to how other file-related functions are implemented in
-  // this codebase.
-
-  // We could check if fd is valid (e.g., stdout/stderr), but since this is just a hint and not
-  // required for correctness, we'll just return success for any fd.
+  // without doing anything. We could check if fd is valid (e.g., stdout/stderr), but since this is
+  // just a hint and not required for correctness, we'll just return success for any fd.
 
   return 0; // __WASI_ESUCCESS
 }
@@ -926,8 +923,8 @@ Word wasi_unstable_fd_advise(Word fd, uint64_t offset, uint64_t len, Word advice
 // len);
 Word wasi_unstable_fd_allocate(Word fd, uint64_t offset, uint64_t len) {
   // fd_allocate is used to ensure that space is allocated for a file.
-  // Since we don't have a real file system in proxy-wasm, we can just return success without doing
-  // anything. This is similar to how other file-related functions are implemented in this codebase.
+  // Since we don't have a real file system in proxy-wasm, we can just return success for
+  // stdout/stderr and an error for other file descriptors.
 
   // We only support stdout and stderr in proxy-wasm, which don't need allocation
   if (fd != 1 /* stdout */ && fd != 2 /* stderr */) {
@@ -965,8 +962,7 @@ Word wasi_unstable_fd_fdstat_set_rights(Word fd, uint64_t fs_rights_base,
     return 8; // __WASI_ERRNO_BADF - Bad file descriptor
   }
 
-  // For stdout and stderr, we don't actually change any rights, but we can pretend it succeeded
-  // This is similar to how other file-related functions are implemented in this codebase
+  // For stdout and stderr, we don't actually change any rights, but we can pretend it succeeded.
   return 0; // __WASI_ESUCCESS
 }
 
@@ -981,8 +977,7 @@ Word wasi_unstable_fd_filestat_set_size(Word fd, uint64_t size) {
     return 8; // __WASI_ERRNO_BADF - Bad file descriptor
   }
 
-  // For stdout and stderr, we don't actually change any size, but we can pretend it succeeded
-  // This is similar to how other file-related functions are implemented in this codebase
+  // For stdout and stderr, we don't actually change any size, but we can pretend it succeeded.
   return 0; // __WASI_ESUCCESS
 }
 
@@ -999,7 +994,6 @@ Word wasi_unstable_fd_filestat_set_times(Word fd, uint64_t atim, uint64_t mtim, 
   }
 
   // For stdout and stderr, we don't actually change any times, but we can pretend it succeeded
-  // This is similar to how other file-related functions are implemented in this codebase
   return 0; // __WASI_ESUCCESS
 }
 
@@ -1008,8 +1002,8 @@ Word wasi_unstable_fd_filestat_set_times(Word fd, uint64_t atim, uint64_t mtim, 
 Word wasi_unstable_fd_pread(Word fd, Word iovs_ptr, Word iovs_len, uint64_t offset,
                             Word nread_ptr) {
   // fd_pread is used to read from a file descriptor at a given offset.
-  // Since we don't have a real file system in proxy-wasm, we can just return an error.
-  // This is similar to how fd_read is implemented in this codebase.
+  // Since we don't have a real file system in proxy-wasm, we can just return success for
+  // stdout/stderr and an error for other file descriptors.
 
   // We don't support reading from any files in proxy-wasm
   return 52; // __WASI_ERRNO_ENOSYS - Function not implemented
@@ -1023,7 +1017,6 @@ Word wasi_unstable_fd_pwrite(Word fd, Word iovs_ptr, Word iovs_len, uint64_t off
 
   // fd_pwrite is used to write to a file descriptor at a given offset.
   // In proxy-wasm, we only support writing to stdout and stderr, and we don't support offsets.
-  // We'll implement this similar to fd_write but return an error for non-stdout/stderr fds.
 
   // Check if fd is stdout or stderr
   if (fd != 1 /* stdout */ && fd != 2 /* stderr */) {
@@ -1031,7 +1024,6 @@ Word wasi_unstable_fd_pwrite(Word fd, Word iovs_ptr, Word iovs_len, uint64_t off
   }
 
   // For stdout and stderr, we'll just ignore the offset and write the data
-  // This is similar to how fd_write is implemented in this codebase
   Word nwritten(0);
   auto result = writevImpl(fd, iovs_ptr, iovs_len, &nwritten);
   if (result != 0) { // __WASI_ESUCCESS

--- a/src/exports.cc
+++ b/src/exports.cc
@@ -1282,6 +1282,9 @@ Word wasi_unstable_poll_oneoff(Word /*in*/, Word /*out*/, Word /*nsubscriptions*
     return 21; // __WASI_EFAULT - If there is a failure setting memory
   }
 
+  // Go runtime requires poll_oneoff to return ESUCCESS. See
+  // https://github.com/golang/go/blob/0886e65b119e5be88846b1580451dc2b0d6f6fd0/src/runtime/os_wasip1.go#L186-L188
+  // and more context in github.com/proxy-wasm/proxy-wasm-cpp-host/issues/497.
   return 0; // __WASI_ESUCCESS
 }
 

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -103,6 +103,7 @@ private:
   std::shared_ptr<WasmBase> wasm_;
 };
 
+// NOLINT(readability-function-size)
 void WasmBase::registerCallbacks() {
 #define _REGISTER(_fn)                                                                             \
   wasm_vm_->registerCallback(                                                                      \
@@ -379,28 +380,56 @@ ContextBase *WasmBase::getRootContext(const std::shared_ptr<PluginBase> &plugin,
 void WasmBase::startVm(ContextBase *root_context) {
   // wasi_snapshot_preview1.clock_time_get
   wasm_vm_->setRestrictedCallback(
-      true, {// emscripten
-             "env.emscripten_notify_memory_growth",
-             // logging (Proxy-Wasm)
-             "env.proxy_log",
-             // logging (stdout/stderr)
-             "wasi_unstable.fd_write", "wasi_snapshot_preview1.fd_write",
-             // args
-             "wasi_unstable.args_sizes_get", "wasi_snapshot_preview1.args_sizes_get",
-             "wasi_unstable.args_get", "wasi_snapshot_preview1.args_get",
-             // environment variables
-             "wasi_unstable.environ_sizes_get", "wasi_snapshot_preview1.environ_sizes_get",
-             "wasi_unstable.environ_get", "wasi_snapshot_preview1.environ_get",
-             // preopened files/directories
-             "wasi_unstable.fd_prestat_get", "wasi_snapshot_preview1.fd_prestat_get",
-             "wasi_unstable.fd_prestat_dir_name", "wasi_snapshot_preview1.fd_prestat_dir_name",
-             // time
-             "wasi_unstable.clock_time_get", "wasi_snapshot_preview1.clock_time_get",
-             // random
-             "wasi_unstable.random_get", "wasi_snapshot_preview1.random_get",
-             // Go runtime initialization
-             "wasi_unstable.fd_fdstat_get", "wasi_snapshot_preview1.fd_fdstat_get",
-             "wasi_unstable.fd_fdstat_set_flags", "wasi_snapshot_preview1.fd_fdstat_set_flags"});
+      true,
+      {// emscripten
+       "env.emscripten_notify_memory_growth",
+       // logging (Proxy-Wasm)
+       "env.proxy_log",
+       // logging (stdout/stderr)
+       "wasi_unstable.fd_write", "wasi_snapshot_preview1.fd_write",
+       // args
+       "wasi_unstable.args_sizes_get", "wasi_snapshot_preview1.args_sizes_get",
+       "wasi_unstable.args_get", "wasi_snapshot_preview1.args_get",
+       // environment variables
+       "wasi_unstable.environ_sizes_get", "wasi_snapshot_preview1.environ_sizes_get",
+       "wasi_unstable.environ_get", "wasi_snapshot_preview1.environ_get",
+       // preopened files/directories
+       "wasi_unstable.fd_prestat_get", "wasi_snapshot_preview1.fd_prestat_get",
+       "wasi_unstable.fd_prestat_dir_name", "wasi_snapshot_preview1.fd_prestat_dir_name",
+       // time
+       "wasi_unstable.clock_time_get", "wasi_snapshot_preview1.clock_time_get",
+       "wasi_unstable.clock_res_get", "wasi_snapshot_preview1.clock_res_get",
+       // random
+       "wasi_unstable.random_get", "wasi_snapshot_preview1.random_get",
+       // Go runtime initialization
+       "wasi_unstable.fd_fdstat_get", "wasi_snapshot_preview1.fd_fdstat_get",
+       "wasi_unstable.fd_fdstat_set_flags", "wasi_snapshot_preview1.fd_fdstat_set_flags",
+       "wasi_unstable.fd_fdstat_set_rights", "wasi_snapshot_preview1.fd_fdstat_set_rights",
+       "wasi_unstable.path_filestat_get", "wasi_snapshot_preview1.path_filestat_get",
+       "wasi_unstable.fd_filestat_get", "wasi_snapshot_preview1.fd_filestat_get",
+       "wasi_unstable.fd_filestat_set_size", "wasi_snapshot_preview1.fd_filestat_set_size",
+       "wasi_unstable.fd_filestat_set_times", "wasi_snapshot_preview1.fd_filestat_set_times",
+       "wasi_unstable.fd_advise", "wasi_snapshot_preview1.fd_advise", "wasi_unstable.fd_allocate",
+       "wasi_snapshot_preview1.fd_allocate", "wasi_unstable.fd_datasync",
+       "wasi_snapshot_preview1.fd_datasync", "wasi_unstable.fd_pread",
+       "wasi_snapshot_preview1.fd_pread", "wasi_unstable.fd_pwrite",
+       "wasi_snapshot_preview1.fd_pwrite", "wasi_unstable.fd_readdir",
+       "wasi_snapshot_preview1.fd_readdir", "wasi_unstable.fd_renumber",
+       "wasi_snapshot_preview1.fd_renumber", "wasi_unstable.fd_sync",
+       "wasi_snapshot_preview1.fd_sync", "wasi_unstable.fd_tell", "wasi_snapshot_preview1.fd_tell",
+       "wasi_unstable.path_create_directory", "wasi_snapshot_preview1.path_create_directory",
+       "wasi_unstable.path_filestat_set_times", "wasi_snapshot_preview1.path_filestat_set_times",
+       "wasi_unstable.path_link", "wasi_snapshot_preview1.path_link", "wasi_unstable.path_readlink",
+       "wasi_snapshot_preview1.path_readlink", "wasi_unstable.path_remove_directory",
+       "wasi_snapshot_preview1.path_remove_directory", "wasi_unstable.path_rename",
+       "wasi_snapshot_preview1.path_rename", "wasi_unstable.path_symlink",
+       "wasi_snapshot_preview1.path_symlink", "wasi_unstable.path_unlink_file",
+       "wasi_snapshot_preview1.path_unlink_file", "wasi_unstable.poll_oneoff",
+       "wasi_snapshot_preview1.poll_oneoff", "wasi_unstable.sock_accept",
+       "wasi_snapshot_preview1.sock_accept", "wasi_unstable.sock_recv",
+       "wasi_snapshot_preview1.sock_recv", "wasi_unstable.sock_send",
+       "wasi_snapshot_preview1.sock_send", "wasi_unstable.sock_shutdown",
+       "wasi_snapshot_preview1.sock_shutdown"});
   if (_initialize_) {
     // WASI reactor.
     _initialize_(root_context);

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -103,8 +103,7 @@ private:
   std::shared_ptr<WasmBase> wasm_;
 };
 
-// NOLINT(readability-function-size)
-void WasmBase::registerCallbacks() {
+void WasmBase::registerCallbacks() { // NOLINT(readability-function-size)
 #define _REGISTER(_fn)                                                                             \
   wasm_vm_->registerCallback(                                                                      \
       "env", #_fn, &exports::_fn,                                                                  \
@@ -393,43 +392,52 @@ void WasmBase::startVm(ContextBase *root_context) {
        // environment variables
        "wasi_unstable.environ_sizes_get", "wasi_snapshot_preview1.environ_sizes_get",
        "wasi_unstable.environ_get", "wasi_snapshot_preview1.environ_get",
-       // preopened files/directories
-       "wasi_unstable.fd_prestat_get", "wasi_snapshot_preview1.fd_prestat_get",
-       "wasi_unstable.fd_prestat_dir_name", "wasi_snapshot_preview1.fd_prestat_dir_name",
        // time
        "wasi_unstable.clock_time_get", "wasi_snapshot_preview1.clock_time_get",
        "wasi_unstable.clock_res_get", "wasi_snapshot_preview1.clock_res_get",
        // random
        "wasi_unstable.random_get", "wasi_snapshot_preview1.random_get",
        // Go runtime initialization
+       "wasi_unstable.poll_oneoff", "wasi_snapshot_preview1.poll_oneoff",
        "wasi_unstable.fd_fdstat_get", "wasi_snapshot_preview1.fd_fdstat_get",
        "wasi_unstable.fd_fdstat_set_flags", "wasi_snapshot_preview1.fd_fdstat_set_flags",
-       "wasi_unstable.fd_fdstat_set_rights", "wasi_snapshot_preview1.fd_fdstat_set_rights",
-       "wasi_unstable.path_filestat_get", "wasi_snapshot_preview1.path_filestat_get",
-       "wasi_unstable.fd_filestat_get", "wasi_snapshot_preview1.fd_filestat_get",
-       "wasi_unstable.fd_filestat_set_size", "wasi_snapshot_preview1.fd_filestat_set_size",
-       "wasi_unstable.fd_filestat_set_times", "wasi_snapshot_preview1.fd_filestat_set_times",
-       "wasi_unstable.fd_advise", "wasi_snapshot_preview1.fd_advise", "wasi_unstable.fd_allocate",
-       "wasi_snapshot_preview1.fd_allocate", "wasi_unstable.fd_datasync",
-       "wasi_snapshot_preview1.fd_datasync", "wasi_unstable.fd_pread",
-       "wasi_snapshot_preview1.fd_pread", "wasi_unstable.fd_pwrite",
-       "wasi_snapshot_preview1.fd_pwrite", "wasi_unstable.fd_readdir",
-       "wasi_snapshot_preview1.fd_readdir", "wasi_unstable.fd_renumber",
-       "wasi_snapshot_preview1.fd_renumber", "wasi_unstable.fd_sync",
-       "wasi_snapshot_preview1.fd_sync", "wasi_unstable.fd_tell", "wasi_snapshot_preview1.fd_tell",
-       "wasi_unstable.path_create_directory", "wasi_snapshot_preview1.path_create_directory",
-       "wasi_unstable.path_filestat_set_times", "wasi_snapshot_preview1.path_filestat_set_times",
-       "wasi_unstable.path_link", "wasi_snapshot_preview1.path_link", "wasi_unstable.path_readlink",
-       "wasi_snapshot_preview1.path_readlink", "wasi_unstable.path_remove_directory",
-       "wasi_snapshot_preview1.path_remove_directory", "wasi_unstable.path_rename",
-       "wasi_snapshot_preview1.path_rename", "wasi_unstable.path_symlink",
-       "wasi_snapshot_preview1.path_symlink", "wasi_unstable.path_unlink_file",
-       "wasi_snapshot_preview1.path_unlink_file", "wasi_unstable.poll_oneoff",
-       "wasi_snapshot_preview1.poll_oneoff", "wasi_unstable.sock_accept",
-       "wasi_snapshot_preview1.sock_accept", "wasi_unstable.sock_recv",
-       "wasi_snapshot_preview1.sock_recv", "wasi_unstable.sock_send",
-       "wasi_snapshot_preview1.sock_send", "wasi_unstable.sock_shutdown",
-       "wasi_snapshot_preview1.sock_shutdown"});
+       // None of the following wasi functions _should_ be called during
+       // initialization, but global variable initialization happens during
+       // `_initialize`, which means what happens during this phase is fully up
+       // to the wasm module author's code and their compiler implementation.
+       // For Go, module initializers run during this phase as well.
+       //
+       // Allow all of these (for the most part, they just return ENOTSUP) to
+       // maximize compatibility and prevent issues upon updating compiler
+       // versions.
+       "wasi_unstable.fd_advise", "wasi_snapshot_preview1.fd_advise",                             //
+       "wasi_unstable.fd_allocate", "wasi_snapshot_preview1.fd_allocate",                         //
+       "wasi_unstable.fd_datasync", "wasi_snapshot_preview1.fd_datasync",                         //
+       "wasi_unstable.fd_fdstat_set_rights", "wasi_snapshot_preview1.fd_fdstat_set_rights",       //
+       "wasi_unstable.fd_filestat_get", "wasi_snapshot_preview1.fd_filestat_get",                 //
+       "wasi_unstable.fd_filestat_set_size", "wasi_snapshot_preview1.fd_filestat_set_size",       //
+       "wasi_unstable.fd_filestat_set_times", "wasi_snapshot_preview1.fd_filestat_set_times",     //
+       "wasi_unstable.fd_pread", "wasi_snapshot_preview1.fd_pread",                               //
+       "wasi_unstable.fd_prestat_dir_name", "wasi_snapshot_preview1.fd_prestat_dir_name",         //
+       "wasi_unstable.fd_prestat_get", "wasi_snapshot_preview1.fd_prestat_get",                   //
+       "wasi_unstable.fd_pwrite", "wasi_snapshot_preview1.fd_pwrite",                             //
+       "wasi_unstable.fd_readdir", "wasi_snapshot_preview1.fd_readdir",                           //
+       "wasi_unstable.fd_renumber", "wasi_snapshot_preview1.fd_renumber",                         //
+       "wasi_unstable.fd_sync", "wasi_snapshot_preview1.fd_sync",                                 //
+       "wasi_unstable.fd_tell", "wasi_snapshot_preview1.fd_tell",                                 //
+       "wasi_unstable.path_create_directory", "wasi_snapshot_preview1.path_create_directory",     //
+       "wasi_unstable.path_filestat_get", "wasi_snapshot_preview1.path_filestat_get",             //
+       "wasi_unstable.path_filestat_set_times", "wasi_snapshot_preview1.path_filestat_set_times", //
+       "wasi_unstable.path_link", "wasi_snapshot_preview1.path_link",                             //
+       "wasi_unstable.path_readlink", "wasi_snapshot_preview1.path_readlink",                     //
+       "wasi_unstable.path_remove_directory", "wasi_snapshot_preview1.path_remove_directory",     //
+       "wasi_unstable.path_rename", "wasi_snapshot_preview1.path_rename",                         //
+       "wasi_unstable.path_symlink", "wasi_snapshot_preview1.path_symlink",                       //
+       "wasi_unstable.path_unlink_file", "wasi_snapshot_preview1.path_unlink_file",               //
+       "wasi_unstable.sock_accept", "wasi_snapshot_preview1.sock_accept",                         //
+       "wasi_unstable.sock_recv", "wasi_snapshot_preview1.sock_recv",                             //
+       "wasi_unstable.sock_send", "wasi_snapshot_preview1.sock_send",                             //
+       "wasi_unstable.sock_shutdown", "wasi_snapshot_preview1.sock_shutdown"});
   if (_initialize_) {
     // WASI reactor.
     _initialize_(root_context);


### PR DESCRIPTION
Rebases and updates #433. Original PR discussion follows:

---

In https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/427, a portion of the wasi hostcalls was added, but not all. Now, all the wasi hostcalls have been included, and their stability has been verified in our multiple go 1.24 compiled wasm plugins