### PR TITLE
Add getFunction calls for endianness test function signatures

### DIFF
--- a/src/null/null_plugin.cc
+++ b/src/null/null_plugin.cc
@@ -259,6 +259,28 @@ void NullPlugin::getFunction(std::string_view function_name, WasmCallWord<3> *f)
   }
 }
 
+void NullPlugin::getFunction(std::string_view function_name, WasmCall_lf *f) {
+  error("Unexpected getFunction for testing signature WasmCall_lf: " + std::string(function_name));
+  *f = nullptr;
+}
+
+void NullPlugin::getFunction(std::string_view function_name, WasmCall_fff *f) {
+  error("Unexpected getFunction for testing signature WasmCall_fff: " + std::string(function_name));
+  *f = nullptr;
+}
+
+void NullPlugin::getFunction(std::string_view function_name, WasmCall_dfff *f) {
+  error("Unexpected getFunction for testing signature WasmCall_dfff: " +
+        std::string(function_name));
+  *f = nullptr;
+}
+
+void NullPlugin::getFunction(std::string_view function_name, WasmCall_WWlfd *f) {
+  error("Unexpected getFunction for testing signature WasmCall_WWlfd: " +
+        std::string(function_name));
+  *f = nullptr;
+}
+
 null_plugin::Context *NullPlugin::ensureContext(uint64_t context_id, uint64_t root_context_id) {
   auto e = context_map_.insert(std::make_pair(context_id, nullptr));
   if (e.second) {


### PR DESCRIPTION
These missing functions (added through the new function call types in https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/525) result in the following linker error when compiling against NullVM:

```
ld: error: undefined symbol: proxy_wasm::NullPlugin::getFunction(std::__u::basic_string_view<char, std::__u::char_traits<char>>, std::__u::function<proxy_wasm::Word (proxy_wasm::ContextBase*, proxy_wasm::Word, unsigned long, float, double)>*)
>>> referenced by null_plugin.cc
>>>               blaze-out/k8-fastbuild/_objs/null_lib/null_plugin.pic.o:(vtable for proxy_wasm::NullPlugin)

ld: error: undefined symbol: proxy_wasm::NullPlugin::getFunction(std::__u::basic_string_view<char, std::__u::char_traits<char>>, std::__u::function<unsigned long (proxy_wasm::ContextBase*, float)>*)
>>> referenced by null_plugin.cc
>>>               blaze-out/k8-fastbuild/_objs/null_lib/null_plugin.pic.o:(vtable for proxy_wasm::NullPlugin)

ld: error: undefined symbol: proxy_wasm::NullPlugin::getFunction(std::__u::basic_string_view<char, std::__u::char_traits<char>>, std::__u::function<float (proxy_wasm::ContextBase*, float, float)>*)
>>> referenced by null_plugin.cc
>>>               blaze-out/k8-fastbuild/_objs/null_lib/null_plugin.pic.o:(vtable for proxy_wasm::NullPlugin)

ld: error: undefined symbol: proxy_wasm::NullPlugin::getFunction(std::__u::basic_string_view<char, std::__u::char_traits<char>>, std::__u::function<double (proxy_wasm::ContextBase*, float, float, float)>*)
>>> referenced by null_plugin.cc
>>>               blaze-out/k8-fastbuild/_objs/null_lib/null_plugin.pic.o:(vtable for proxy_wasm::NullPlugin)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```