### PR TITLE
Add `WasmVm::serialize` method to get serialized AOT compiled module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -305,7 +305,7 @@ jobs:
         ${{ matrix.run_under }}
         bazel ${{ matrix.action }}
         --verbose_failures
-        --test_output=errors
+        --test_output=all
         --define engine=${{ matrix.engine }}
         ${{ matrix.flags }}
         -- //test/... ${{ matrix.targets }}
@@ -316,7 +316,7 @@ jobs:
         ${{ matrix.run_under }}
         bazel ${{ matrix.action }}
         --verbose_failures
-        --test_output=errors
+        --test_output=all
         --define engine=${{ matrix.engine }}
         ${{ matrix.flags }}
         --per_file_copt=src/signature_util.cc,test/signature_util_test.cc@-DPROXY_WASM_VERIFY_WITH_ED25519_PUBKEY=\"$(xxd -p -c 256 test/test_data/signature_key1.pub | cut -c3- | tr -d '\n')\"

--- a/BUILD
+++ b/BUILD
@@ -133,6 +133,7 @@ cc_library(
         "PROXY_WASM_HOST_ENGINE_V8",
     ],
     deps = [
+        ":base_lib",
         ":wasm_vm_headers",
         "//bazel:wee8_no_pointer_compression",
     ],
@@ -220,6 +221,7 @@ cc_library(
         ],
     }),
     deps = [
+        ":base_lib",
         ":wasm_vm_headers",
         "@com_github_bytecodealliance_wasmtime//:wasmtime_lib",
     ],

--- a/include/proxy-wasm/bytecode_util.h
+++ b/include/proxy-wasm/bytecode_util.h
@@ -61,15 +61,25 @@ public:
                                    std::unordered_map<uint32_t, std::string> &ret);
 
   /**
-   * getStrippedSource gets Wasm module without Custom Sections to save some memory in workers.
+   * getStrippedSource gets Wasm module without precompiled sections to save some memory in workers.
    * @param bytecode is the original bytecode.
    * @param ret is the reference to the stripped bytecode or a copy of the original bytecode.
    * @return indicates whether parsing succeeded or not.
    */
   static bool getStrippedSource(std::string_view bytecode, std::string &ret);
 
-private:
-  static bool parseVarint(const char *&pos, const char *end, uint32_t &ret);
+  /**
+   * writeModuleWithCustomSection returns a new wasm module comprised of the supplied module with
+   * the supplied custom section overwriting any existing custom sections containing precompiled
+   * precompiled content.
+   * @param bytecode is the bytecode to add the custom section to.
+   * @param section_name is the section name to add/overwrite.
+   * @param section_contents are the contents of the new section.
+   * @return a string containing the sum of the original bytecode with the new section.
+   */
+  static std::optional<std::string> writeModuleWithCustomSection(std::string_view bytecode,
+                                                                 std::string_view section_name,
+                                                                 std::string_view section_contents);
 };
 
 } // namespace proxy_wasm

--- a/include/proxy-wasm/null_vm.h
+++ b/include/proxy-wasm/null_vm.h
@@ -34,6 +34,9 @@ struct NullVm : public WasmVm {
   // WasmVm
   std::string_view getEngineName() override { return "null"; }
   Cloneable cloneable() override { return Cloneable::InstantiatedModule; };
+  std::optional<std::string> serialize(std::string_view original_bytecode) override {
+    return std::nullopt;
+  }
   std::unique_ptr<WasmVm> clone() override;
   bool load(std::string_view plugin_name, std::string_view precompiled,
             const std::unordered_map<uint32_t, std::string> &function_names) override;

--- a/include/proxy-wasm/wasm_vm.h
+++ b/include/proxy-wasm/wasm_vm.h
@@ -236,6 +236,14 @@ public:
                     const std::unordered_map<uint32_t, std::string> &function_names) = 0;
 
   /**
+   * Serializes the loaded wasm module to a string. Returns true on success. The resulting string
+   * may be saved to storage and passed as a precompiled wasm module to another instance.
+   * @param original_bytecode the bytecode to append the serialized section to.
+   * @return a string containing the serialized wasm module, or nullopt if serialization failed.
+   */
+  virtual std::optional<std::string> serialize(std::string_view original_bytecode) = 0;
+
+  /**
    * Link the WASM code to the host-provided functions, e.g. the ABI. Prior to linking, the module
    * should be loaded and the ABI callbacks registered (see above). Linking should be done once
    * after load().

--- a/include/proxy-wasm/wasm_vm.h
+++ b/include/proxy-wasm/wasm_vm.h
@@ -29,6 +29,25 @@
 
 namespace proxy_wasm {
 
+#ifdef PROXY_WASM_PLATFORM
+#elif defined(__linux__) && defined(__x86_64__)
+#define PROXY_WASM_PLATFORM "linux_x86_64"
+#elif defined(__linux__) && defined(__aarch64__)
+#define PROXY_WASM_PLATFORM "linux_aarch64"
+#elif defined(__linux__) && (defined(__ppc64le__) || defined(__PPC64LE__))
+#define PROXY_WASM_PLATFORM "linux_ppc64le"
+#elif defined(__linux__) && defined(__s390x__)
+#define PROXY_WASM_PLATFORM "linux_s390x"
+#elif defined(__APPLE__) && defined(__x86_64__)
+#define PROXY_WASM_PLATFORM "macos_x86_64"
+#elif defined(__APPLE__) && defined(__arm64__)
+#define PROXY_WASM_PLATFORM "macos_arm64"
+#elif defined(_WIN64) && defined(_M_X64)
+#define PROXY_WASM_PLATFORM "windows_x64"
+#else
+#define PROXY_WASM_PLATFORM ""
+#endif
+
 class ContextBase;
 
 // These are templates and its helper for constructing signatures of functions calling into Wasm

--- a/src/bytecode_util.cc
+++ b/src/bytecode_util.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "include/proxy-wasm/bytecode_util.h"
+#include <string>
 
 #if !defined(_MSC_VER)
 #include <cxxabi.h>
@@ -21,6 +22,102 @@
 #include <cstring>
 
 namespace proxy_wasm {
+namespace {
+
+constexpr char kCustomSectionType = '\0';
+
+bool parseVarint(const char *&pos, const char *end, uint32_t &ret) {
+  uint32_t shift = 0;
+  uint32_t total = 0;
+  uint32_t v;
+  char b;
+  while (pos < end) {
+    if (pos + 1 > end) {
+      // overread
+      return false;
+    }
+    b = *pos++;
+    v = (b & 0x7f);
+    if (shift == 28 && v > 3) {
+      // overflow
+      return false;
+    }
+    total += v << shift;
+    if ((b & 0x80) == 0) {
+      ret = total;
+      return true;
+    }
+    shift += 7;
+    if (shift > 28) {
+      // overflow
+      return false;
+    }
+  }
+  return false;
+}
+
+std::vector<uint8_t> encodeVarint(uint32_t value) {
+  std::vector<uint8_t> ret;
+  while (value >= 0x80) {
+    ret.push_back(static_cast<uint8_t>(value | 0x80));
+    value >>= 7;
+  }
+  ret.push_back(static_cast<uint8_t>(value));
+  return ret;
+}
+
+bool stripMatchingSections(std::string_view bytecode,
+                           std::string_view section_name_substring_to_match, std::string &ret) {
+  // Check Wasm header.
+  if (!BytecodeUtil::checkWasmHeader(bytecode)) {
+    return false;
+  }
+
+  // Skip the Wasm header.
+  const char *pos = bytecode.data() + 8;
+  const char *end = bytecode.data() + bytecode.size();
+  while (pos < end) {
+    const auto *const section_start = pos;
+    if (pos + 1 > end) {
+      return false;
+    }
+    const auto section_type = *pos++;
+    uint32_t section_len = 0;
+    if (!parseVarint(pos, end, section_len) || pos + section_len > end) {
+      return false;
+    }
+    if (section_type == kCustomSectionType) {
+      const auto *const section_data_start = pos;
+      uint32_t section_name_len = 0;
+      if (!parseVarint(pos, end, section_name_len) || pos + section_name_len > end) {
+        return false;
+      }
+      auto section_name = std::string_view(pos, section_name_len);
+      if (section_name.find(section_name_substring_to_match) != std::string::npos) {
+        // If this is the first matching section, then save everything before
+        // it, otherwise skip it.
+        if (ret.empty()) {
+          const char *start = bytecode.data();
+          ret.append(start, section_start);
+        }
+      }
+      pos = section_data_start + section_len;
+    } else {
+      pos += section_len;
+      // Save this section if we already saw a custom "precompiled_" section.
+      if (!ret.empty()) {
+        ret.append(section_start, pos);
+      }
+    }
+  }
+  if (ret.empty()) {
+    // Copy the original source code if it is empty.
+    ret = std::string(bytecode);
+  }
+  return true;
+}
+
+} // namespace
 
 bool BytecodeUtil::checkWasmHeader(std::string_view bytecode) {
   // Wasm file header is 8 bytes (magic number + version).
@@ -115,11 +212,11 @@ bool BytecodeUtil::getCustomSection(std::string_view bytecode, std::string_view 
     if (!parseVarint(pos, end, section_len) || pos + section_len > end) {
       return false;
     }
-    if (section_type == 0) {
+    if (section_type == kCustomSectionType) {
       // Custom section.
       const char *section_end = pos + section_len;
       uint32_t section_name_len = 0;
-      if (!BytecodeUtil::parseVarint(pos, section_end, section_name_len) ||
+      if (!parseVarint(pos, section_end, section_name_len) ||
           pos + section_name_len > section_end) {
         return false;
       }
@@ -195,83 +292,35 @@ bool BytecodeUtil::getFunctionNameIndex(std::string_view bytecode,
 }
 
 bool BytecodeUtil::getStrippedSource(std::string_view bytecode, std::string &ret) {
-  // Check Wasm header.
-  if (!checkWasmHeader(bytecode)) {
-    return false;
-  }
-
-  // Skip the Wasm header.
-  const char *pos = bytecode.data() + 8;
-  const char *end = bytecode.data() + bytecode.size();
-  while (pos < end) {
-    const auto *const section_start = pos;
-    if (pos + 1 > end) {
-      return false;
-    }
-    const auto section_type = *pos++;
-    uint32_t section_len = 0;
-    if (!parseVarint(pos, end, section_len) || pos + section_len > end) {
-      return false;
-    }
-    if (section_type == 0 /* custom section */) {
-      const auto *const section_data_start = pos;
-      uint32_t section_name_len = 0;
-      if (!parseVarint(pos, end, section_name_len) || pos + section_name_len > end) {
-        return false;
-      }
-      auto section_name = std::string_view(pos, section_name_len);
-      if (section_name.find("precompiled_") != std::string::npos) {
-        // If this is the first "precompiled_" section, then save everything
-        // before it, otherwise skip it.
-        if (ret.empty()) {
-          const char *start = bytecode.data();
-          ret.append(start, section_start);
-        }
-      }
-      pos = section_data_start + section_len;
-    } else {
-      pos += section_len;
-      // Save this section if we already saw a custom "precompiled_" section.
-      if (!ret.empty()) {
-        ret.append(section_start, pos);
-      }
-    }
-  }
-  if (ret.empty()) {
-    // Copy the original source code if it is empty.
-    ret = std::string(bytecode);
-  }
-  return true;
+  return stripMatchingSections(bytecode, "precompiled_", ret);
 }
 
-bool BytecodeUtil::parseVarint(const char *&pos, const char *end, uint32_t &ret) {
-  uint32_t shift = 0;
-  uint32_t total = 0;
-  uint32_t v;
-  char b;
-  while (pos < end) {
-    if (pos + 1 > end) {
-      // overread
-      return false;
-    }
-    b = *pos++;
-    v = (b & 0x7f);
-    if (shift == 28 && v > 3) {
-      // overflow
-      return false;
-    }
-    total += v << shift;
-    if ((b & 0x80) == 0) {
-      ret = total;
-      return true;
-    }
-    shift += 7;
-    if (shift > 28) {
-      // overflow
-      return false;
-    }
+std::optional<std::string>
+BytecodeUtil::writeModuleWithCustomSection(std::string_view bytecode, std::string_view section_name,
+                                           std::string_view section_contents) {
+  if (!checkWasmHeader(bytecode)) {
+    return std::nullopt;
   }
-  return false;
+  std::vector<uint8_t> section_name_len = encodeVarint(section_name.size());
+  std::vector<uint8_t> section_size =
+      encodeVarint(section_name_len.size() + section_name.size() + section_contents.size());
+  int appended_contents_size = /*section_type*/ 1 + section_size.size() + section_name_len.size() +
+                               section_name.size() + section_contents.size();
+  std::string output;
+  // Copy wasm header.
+  if (!stripMatchingSections(bytecode, section_name, output)) {
+    // `bytecode` was an invalid wasm module.
+    return std::nullopt;
+  }
+  output.reserve(output.size() + appended_contents_size);
+  output.push_back(kCustomSectionType);
+  output.append(
+      std::string_view(reinterpret_cast<char *>(section_size.data()), section_size.size()));
+  output.append(
+      std::string_view(reinterpret_cast<char *>(section_name_len.data()), section_name_len.size()));
+  output.append(section_name);
+  output.append(section_contents);
+  return output;
 }
 
 } // namespace proxy_wasm

--- a/src/v8/v8.cc
+++ b/src/v8/v8.cc
@@ -360,6 +360,18 @@ std::unique_ptr<WasmVm> V8::clone() {
 
 #if defined(__linux__) && defined(__x86_64__)
 #define WEE8_PLATFORM "linux_x86_64"
+#elif defined(__linux__) && defined(__aarch64__)
+#define WEE8_PLATFORM "linux_aarch64"
+#elif defined(__linux__) && (defined(__ppc64le__) || defined(__PPC64LE__))
+#define WEE8_PLATFORM "linux_ppc64le"
+#elif defined(__linux__) && defined(__s390x__)
+#define WEE8_PLATFORM "linux_s390x"
+#elif defined(__APPLE__) && defined(__x86_64__)
+#define WEE8_PLATFORM "macos_x86_64"
+#elif defined(__APPLE__) && defined(__arm64__)
+#define WEE8_PLATFORM "macos_arm64"
+#elif defined(_WIN64) && defined(_M_X64)
+#define WEE8_PLATFORM "windows_x64"
 #else
 #define WEE8_PLATFORM ""
 #endif

--- a/src/v8/v8.cc
+++ b/src/v8/v8.cc
@@ -358,30 +358,12 @@ std::unique_ptr<WasmVm> V8::clone() {
   return clone;
 }
 
-#if defined(__linux__) && defined(__x86_64__)
-#define WEE8_PLATFORM "linux_x86_64"
-#elif defined(__linux__) && defined(__aarch64__)
-#define WEE8_PLATFORM "linux_aarch64"
-#elif defined(__linux__) && (defined(__ppc64le__) || defined(__PPC64LE__))
-#define WEE8_PLATFORM "linux_ppc64le"
-#elif defined(__linux__) && defined(__s390x__)
-#define WEE8_PLATFORM "linux_s390x"
-#elif defined(__APPLE__) && defined(__x86_64__)
-#define WEE8_PLATFORM "macos_x86_64"
-#elif defined(__APPLE__) && defined(__arm64__)
-#define WEE8_PLATFORM "macos_arm64"
-#elif defined(_WIN64) && defined(_M_X64)
-#define WEE8_PLATFORM "windows_x64"
-#else
-#define WEE8_PLATFORM ""
-#endif
-
 std::string_view V8::getPrecompiledSectionName() {
   static const auto name =
-      sizeof(WEE8_PLATFORM) - 1 > 0
+      sizeof(PROXY_WASM_PLATFORM) - 1 > 0
           ? ("precompiled_wee8_v" + std::to_string(V8_MAJOR_VERSION) + "." +
              std::to_string(V8_MINOR_VERSION) + "." + std::to_string(V8_BUILD_NUMBER) + "." +
-             std::to_string(V8_PATCH_LEVEL) + "_" + WEE8_PLATFORM)
+             std::to_string(V8_PATCH_LEVEL) + "_" + PROXY_WASM_PLATFORM)
           : "";
   return name;
 }

--- a/src/v8/v8.cc
+++ b/src/v8/v8.cc
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "include/proxy-wasm/limits.h"
+#include "include/proxy-wasm/bytecode_util.h"
 
 #include "absl/strings/str_format.h"
 #include "include/v8-initialization.h"
@@ -78,6 +79,7 @@ public:
 
   bool load(std::string_view bytecode, std::string_view precompiled,
             const std::unordered_map<uint32_t, std::string> &function_names) override;
+  std::optional<std::string> serialize(std::string_view original_bytecode) override;
   std::string_view getPrecompiledSectionName() override;
   bool link(std::string_view debug_name) override;
 
@@ -311,6 +313,20 @@ bool V8::load(std::string_view bytecode, std::string_view precompiled,
   function_names_index_ = function_names;
 
   return true;
+}
+
+std::optional<std::string> V8::serialize(std::string_view original_bytecode) {
+  if (module_ == nullptr) {
+    return std::nullopt;
+  }
+  wasm::vec<byte_t> serialized = module_->serialize();
+  if (serialized.invalid()) {
+    integration()->error("Failed to serialize wasm module.");
+    return std::nullopt;
+  }
+  return BytecodeUtil::writeModuleWithCustomSection(
+      original_bytecode, getPrecompiledSectionName(),
+      std::string_view(serialized.get(), serialized.size()));
 }
 
 std::unique_ptr<WasmVm> V8::clone() {

--- a/src/wamr/wamr.cc
+++ b/src/wamr/wamr.cc
@@ -60,6 +60,9 @@ public:
   std::string_view getPrecompiledSectionName() override { return "wamr-aot"; }
 
   Cloneable cloneable() override { return Cloneable::CompiledBytecode; }
+  std::optional<std::string> serialize(std::string_view original_bytecode) override {
+    return std::nullopt;
+  }
   std::unique_ptr<WasmVm> clone() override;
 
   bool load(std::string_view bytecode, std::string_view precompiled,

--- a/src/wasmedge/wasmedge.cc
+++ b/src/wasmedge/wasmedge.cc
@@ -252,6 +252,9 @@ public:
   std::string_view getPrecompiledSectionName() override { return ""; }
 
   Cloneable cloneable() override { return Cloneable::NotCloneable; }
+  std::optional<std::string> serialize(std::string_view original_bytecode) override {
+    return std::nullopt;
+  }
   std::unique_ptr<WasmVm> clone() override { return nullptr; }
 
   bool load(std::string_view bytecode, std::string_view precompiled,

--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -20,9 +20,11 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include "include/proxy-wasm/limits.h"
 #include "include/proxy-wasm/word.h"
+#include "include/proxy-wasm/bytecode_util.h"
 
 #include "crates/c-api/include/wasmtime.hh" // IWYU pragma: keep
 
@@ -96,10 +98,11 @@ public:
 
   std::string_view getEngineName() override { return "wasmtime"; }
   Cloneable cloneable() override { return Cloneable::CompiledBytecode; }
-  std::string_view getPrecompiledSectionName() override { return ""; }
+  std::string_view getPrecompiledSectionName() override;
 
   bool load(std::string_view bytecode, std::string_view precompiled,
             const std::unordered_map<uint32_t, std::string> &function_names) override;
+  std::optional<std::string> serialize(std::string_view original_bytecode) override;
   bool link(std::string_view debug_name) override;
   std::unique_ptr<WasmVm> clone() override;
   uint64_t getMemorySize() override;
@@ -202,6 +205,21 @@ bool Wasmtime::load(std::string_view bytecode, std::string_view precompiled,
   }
   module_.emplace(module.ok());
   return true;
+}
+
+std::optional<std::string> Wasmtime::serialize(std::string_view original_bytecode) {
+  if (!module_.has_value()) {
+    return std::nullopt;
+  }
+  Result<std::vector<uint8_t>> serialized = module_->serialize();
+  if (!serialized) {
+    integration()->error("Failed to serialize wasm module: " + serialized.err().message());
+    return std::nullopt;
+  }
+  return BytecodeUtil::writeModuleWithCustomSection(
+      original_bytecode, getPrecompiledSectionName(),
+      std::string_view(reinterpret_cast<char *>(serialized.ok_ref().data()),
+                       serialized.ok_ref().size()));
 }
 
 std::unique_ptr<WasmVm> Wasmtime::clone() {
@@ -429,6 +447,9 @@ void Wasmtime::getModuleFunctionImpl(std::string_view function_name,
 };
 
 void Wasmtime::warm() { initStore(); }
+
+// Wasmtime sticks
+std::string_view Wasmtime::getPrecompiledSectionName() { return "precompiled_wasmtime_bytecode"; }
 
 } // namespace wasmtime
 

--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -172,21 +172,35 @@ void Wasmtime::initStore() {
                   /*memories=*/1);
 }
 
-bool Wasmtime::load(std::string_view bytecode, std::string_view /*precompiled*/,
+bool Wasmtime::load(std::string_view bytecode, std::string_view precompiled,
                     const std::unordered_map<uint32_t, std::string> & /*function_names*/) {
+
   initStore();
   if (!store_.has_value()) {
     return false;
   }
 
-  Result<Module> module =
-      Module::compile(*engine(), std::span((uint8_t *)bytecode.data(), bytecode.size()));
+  Result<Module> module(::wasmtime::Error("Unable to load Wasm module: zero-length."));
+  if (!precompiled.empty()) {
+    module = Module::deserialize(*engine(),
+                                 std::span((uint8_t *)precompiled.data(), precompiled.size()));
+    if (module) {
+      module_.emplace(module.ok());
+      return true;
+    }
+  }
+  if (bytecode.empty()) {
+    fail(FailState::UnableToInitializeCode,
+         "Failed to deserialize Wasm module: " + module.err().message());
+    return false;
+  }
+  module = Module::compile(*engine(), std::span((uint8_t *)bytecode.data(), bytecode.size()));
   if (!module) {
-    fail(FailState::UnableToInitializeCode, "Failed to load Wasm code: " + module.err().message());
+    fail(FailState::UnableToInitializeCode,
+         "Failed to load Wasm module: " + module.err().message());
     return false;
   }
   module_.emplace(module.ok());
-
   return true;
 }
 

--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -26,6 +26,7 @@
 #include "include/proxy-wasm/word.h"
 #include "include/proxy-wasm/bytecode_util.h"
 
+#include "crates/c-api/include/wasmtime.h"  // IWYU pragma: keep
 #include "crates/c-api/include/wasmtime.hh" // IWYU pragma: keep
 
 namespace wasmtime::detail {
@@ -449,7 +450,13 @@ void Wasmtime::getModuleFunctionImpl(std::string_view function_name,
 void Wasmtime::warm() { initStore(); }
 
 // Wasmtime sticks
-std::string_view Wasmtime::getPrecompiledSectionName() { return "precompiled_wasmtime_bytecode"; }
+std::string_view Wasmtime::getPrecompiledSectionName() {
+  static const auto name =
+      sizeof(PROXY_WASM_PLATFORM) - 1 > 0
+          ? ("precompiled_wasmtime_v" + std::string(WASMTIME_VERSION) + "_" + PROXY_WASM_PLATFORM)
+          : "";
+  return name;
+}
 
 } // namespace wasmtime
 

--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -449,7 +449,6 @@ void Wasmtime::getModuleFunctionImpl(std::string_view function_name,
 
 void Wasmtime::warm() { initStore(); }
 
-// Wasmtime sticks
 std::string_view Wasmtime::getPrecompiledSectionName() {
   static const auto name =
       sizeof(PROXY_WASM_PLATFORM) - 1 > 0

--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -178,13 +178,13 @@ void Wasmtime::initStore() {
 
 bool Wasmtime::load(std::string_view bytecode, std::string_view precompiled,
                     const std::unordered_map<uint32_t, std::string> & /*function_names*/) {
-
   initStore();
   if (!store_.has_value()) {
     return false;
   }
 
-  Result<Module> module(::wasmtime::Error("Unable to load Wasm module: zero-length."));
+  // Error message used if both precompiled and bytecode are empty.
+  Result<Module> module(::wasmtime::Error("Unable to load Wasm module: empty"));
   if (!precompiled.empty()) {
     module = Module::deserialize(*engine(),
                                  std::span((uint8_t *)precompiled.data(), precompiled.size()));

--- a/test/bytecode_util_test.cc
+++ b/test/bytecode_util_test.cc
@@ -123,4 +123,32 @@ TEST(TestBytecodeUtil, getAbiVersion) {
   EXPECT_EQ(actual, proxy_wasm::AbiVersion::ProxyWasm_0_2_0);
 }
 
+TEST(TestWriteModuleWithCustomSection, HasCustomSection) {
+  const std::string source = readTestWasmFile("abi_export.wasm");
+
+  std::optional<std::string> result = BytecodeUtil::writeModuleWithCustomSection(
+      source, "my_custom_section", "my_custom_section_contents");
+  ASSERT_NE(result, std::nullopt);
+
+  std::string_view custom_section_contents;
+  ASSERT_TRUE(
+      BytecodeUtil::getCustomSection(*result, "my_custom_section", custom_section_contents));
+  EXPECT_EQ(custom_section_contents, "my_custom_section_contents");
+}
+
+TEST(TestWriteModuleWithCustomSection, OverwritesCustomSectionWithSameName) {
+  const std::string source = readTestWasmFile("abi_export.wasm");
+
+  std::optional<std::string> result = BytecodeUtil::writeModuleWithCustomSection(
+      source, "my_custom_section", "my_custom_section_contents");
+  ASSERT_NE(result, std::nullopt);
+  result = BytecodeUtil::writeModuleWithCustomSection(*result, "my_custom_section", "new_contents");
+  ASSERT_NE(result, std::nullopt);
+
+  std::string_view custom_section_contents;
+  ASSERT_TRUE(
+      BytecodeUtil::getCustomSection(*result, "my_custom_section", custom_section_contents));
+  EXPECT_EQ(custom_section_contents, "new_contents");
+}
+
 } // namespace proxy_wasm

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -223,7 +223,8 @@ TEST_P(TestVm, SerializeAndDeserializeRoundTripWorks) {
       std::chrono::steady_clock::now();
 
   std::cout << "Precompiled load time: " << precompiled_load_end - precompiled_load_start << "\n"
-            << "Unprecompiled load time: " << unprecompiled_load_end - unprecompiled_load_start;
+            << "Unprecompiled load time: " << unprecompiled_load_end - unprecompiled_load_start
+            << "\n";
   EXPECT_LT((precompiled_load_end - precompiled_load_start) * 2,
             (unprecompiled_load_end - unprecompiled_load_start));
 }

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -203,11 +203,9 @@ TEST_P(TestVm, SerializeAndDeserializeRoundTripWorks) {
   ASSERT_FALSE(source.empty());
   TestWasm wasm(std::move(vm_));
 
-  std::chrono::time_point<std::chrono::steady_clock> unprecompiled_load_start =
-      std::chrono::steady_clock::now();
+  auto unprecompiled_load_start = std::chrono::steady_clock::now();
   ASSERT_TRUE(wasm.load(source, false));
-  std::chrono::time_point<std::chrono::steady_clock> unprecompiled_load_end =
-      std::chrono::steady_clock::now();
+  auto unprecompiled_load_end = std::chrono::steady_clock::now();
 
   std::optional<std::string> serialized = wasm.wasm_vm()->serialize(source);
   ASSERT_NE(serialized, std::nullopt);
@@ -216,11 +214,9 @@ TEST_P(TestVm, SerializeAndDeserializeRoundTripWorks) {
   ASSERT_TRUE(TestWasm(makeVm(engine_)).load(*serialized, false));
 
   // Loads faster now that it is precompiled:
-  std::chrono::time_point<std::chrono::steady_clock> precompiled_load_start =
-      std::chrono::steady_clock::now();
+  auto precompiled_load_start = std::chrono::steady_clock::now();
   ASSERT_TRUE(TestWasm(makeVm(engine_)).load(*serialized, true));
-  std::chrono::time_point<std::chrono::steady_clock> precompiled_load_end =
-      std::chrono::steady_clock::now();
+  auto precompiled_load_end = std::chrono::steady_clock::now();
 
   auto precompiled = std::chrono::duration_cast<std::chrono::nanoseconds>(precompiled_load_end -
                                                                           precompiled_load_start)

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -222,11 +222,15 @@ TEST_P(TestVm, SerializeAndDeserializeRoundTripWorks) {
   std::chrono::time_point<std::chrono::steady_clock> precompiled_load_end =
       std::chrono::steady_clock::now();
 
-  std::cout << "Precompiled load time: " << precompiled_load_end - precompiled_load_start << "\n"
-            << "Unprecompiled load time: " << unprecompiled_load_end - unprecompiled_load_start
-            << "\n";
-  EXPECT_LT((precompiled_load_end - precompiled_load_start) * 2,
-            (unprecompiled_load_end - unprecompiled_load_start));
+  auto precompiled = std::chrono::duration_cast<std::chrono::nanoseconds>(precompiled_load_end -
+                                                                          precompiled_load_start)
+                         .count();
+  auto unprecompiled = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                           unprecompiled_load_end - unprecompiled_load_start)
+                           .count();
+  std::cout << "[" << engine_ << "] \"precompiled\" load time: " << precompiled << "ns\n"
+            << "[" << engine_ << "] \"unprecompiled\" load time: " << unprecompiled << "ns\n";
+  EXPECT_LT(precompiled * 2, unprecompiled);
 }
 
 class TestCounterContext : public TestContext {

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -222,6 +222,8 @@ TEST_P(TestVm, SerializeAndDeserializeRoundTripWorks) {
   std::chrono::time_point<std::chrono::steady_clock> precompiled_load_end =
       std::chrono::steady_clock::now();
 
+  std::cout << "Precompiled load time: " << precompiled_load_end - precompiled_load_start << "\n"
+            << "Unprecompiled load time: " << unprecompiled_load_end - unprecompiled_load_start;
   EXPECT_LT((precompiled_load_end - precompiled_load_start) * 2,
             (unprecompiled_load_end - unprecompiled_load_start));
 }

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -203,11 +203,11 @@ TEST_P(TestVm, SerializeAndDeserializeRoundTripWorks) {
   ASSERT_FALSE(source.empty());
   TestWasm wasm(std::move(vm_));
 
-  std::chrono::time_point<std::chrono::system_clock> unprecompiled_load_start =
-      std::chrono::system_clock::now();
+  std::chrono::time_point<std::chrono::steady_clock> unprecompiled_load_start =
+      std::chrono::steady_clock::now();
   ASSERT_TRUE(wasm.load(source, false));
-  std::chrono::time_point<std::chrono::system_clock> unprecompiled_load_end =
-      std::chrono::system_clock::now();
+  std::chrono::time_point<std::chrono::steady_clock> unprecompiled_load_end =
+      std::chrono::steady_clock::now();
 
   std::optional<std::string> serialized = wasm.wasm_vm()->serialize(source);
   ASSERT_NE(serialized, std::nullopt);
@@ -216,11 +216,11 @@ TEST_P(TestVm, SerializeAndDeserializeRoundTripWorks) {
   ASSERT_TRUE(TestWasm(makeVm(engine_)).load(*serialized, false));
 
   // Loads faster now that it is precompiled:
-  std::chrono::time_point<std::chrono::system_clock> precompiled_load_start =
-      std::chrono::system_clock::now();
+  std::chrono::time_point<std::chrono::steady_clock> precompiled_load_start =
+      std::chrono::steady_clock::now();
   ASSERT_TRUE(TestWasm(makeVm(engine_)).load(*serialized, true));
-  std::chrono::time_point<std::chrono::system_clock> precompiled_load_end =
-      std::chrono::system_clock::now();
+  std::chrono::time_point<std::chrono::steady_clock> precompiled_load_end =
+      std::chrono::steady_clock::now();
 
   EXPECT_LT((precompiled_load_end - precompiled_load_start) * 2,
             (unprecompiled_load_end - unprecompiled_load_start));

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -14,6 +14,7 @@
 
 #include "gtest/gtest.h"
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <thread>
@@ -192,6 +193,37 @@ TEST_P(TestVm, Trap2) {
     EXPECT_TRUE(host->isErrorLogged(" - std::panicking::begin_panic"));
     EXPECT_TRUE(host->isErrorLogged(" - trigger2"));
   }
+}
+
+TEST_P(TestVm, SerializeAndDeserializeRoundTripWorks) {
+  if (engine_ != "v8" && engine_ != "wasmtime") {
+    return;
+  }
+  auto source = readTestWasmFile("clock.wasm");
+  ASSERT_FALSE(source.empty());
+  TestWasm wasm(std::move(vm_));
+
+  std::chrono::time_point<std::chrono::system_clock> unprecompiled_load_start =
+      std::chrono::system_clock::now();
+  ASSERT_TRUE(wasm.load(source, false));
+  std::chrono::time_point<std::chrono::system_clock> unprecompiled_load_end =
+      std::chrono::system_clock::now();
+
+  std::optional<std::string> serialized = wasm.wasm_vm()->serialize(source);
+  ASSERT_NE(serialized, std::nullopt);
+
+  // Still loads with allow_precompiled == false:
+  ASSERT_TRUE(TestWasm(makeVm(engine_)).load(*serialized, false));
+
+  // Loads faster now that it is precompiled:
+  std::chrono::time_point<std::chrono::system_clock> precompiled_load_start =
+      std::chrono::system_clock::now();
+  ASSERT_TRUE(TestWasm(makeVm(engine_)).load(*serialized, true));
+  std::chrono::time_point<std::chrono::system_clock> precompiled_load_end =
+      std::chrono::system_clock::now();
+
+  EXPECT_LT((precompiled_load_end - precompiled_load_start) * 2,
+            (unprecompiled_load_end - unprecompiled_load_start));
 }
 
 class TestCounterContext : public TestContext {


### PR DESCRIPTION
This PR contains both serialization and deserialization since we had no testing surface for deserialization, as pointed out in https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/522/changes#r2921882220.

This implements serialization and deserialization for wasmtime and V8.