### PR TITLE
Fix TestVm::Init test to reflect true time to create a warmed thread

### DIFF
--- a/bazel/dependencies.bzl
+++ b/bazel/dependencies.bzl
@@ -14,6 +14,7 @@
 
 load("@aspect_rules_lint//format:repositories.bzl", "rules_lint_dependencies")
 load("@bazel_lib//lib:repositories.bzl", "bazel_lib_dependencies", "bazel_lib_register_toolchains")
+load("@com_google_benchmark//:bazel/benchmark_deps.bzl", "benchmark_deps")
 load("@com_google_googletest//:googletest_deps.bzl", "googletest_deps")
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 load("@envoy_toolshed//sysroot:sysroot.bzl", "setup_sysroots")
@@ -31,6 +32,7 @@ def proxy_wasm_cpp_host_dependencies():
     # Bazel extensions.
     googletest_deps()
     rules_foreign_cc_dependencies()
+    benchmark_deps()
 
     rules_lint_dependencies()
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -193,6 +193,14 @@ def proxy_wasm_cpp_host_repositories():
         },
     )
 
+    maybe(
+        http_archive,
+        name = "com_google_benchmark",
+        sha256 = "9631341c82bac4a288bef951f8b26b41f69021794184ece969f8473977eaa340",
+        strip_prefix = "benchmark-1.9.5",
+        urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.5.tar.gz"],
+    )
+
     # NullVM dependencies.
 
     maybe(

--- a/test/BUILD
+++ b/test/BUILD
@@ -223,9 +223,9 @@ cc_test(
     deps = [
         ":utility_lib",
         "//:lib",
+        "@com_google_benchmark//:benchmark",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@com_google_benchmark//:benchmark",
     ],
 )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -225,6 +225,7 @@ cc_test(
         "//:lib",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
+        "@com_google_benchmark//:benchmark",
     ],
 )
 

--- a/test/wasm_vm_test.cc
+++ b/test/wasm_vm_test.cc
@@ -53,31 +53,23 @@ TEST_P(TestVm, Init) {
     return;
   }
   int expected_warm_time_ns = 0;
-  double expected_warm_time_speedup_factor = 0;
   if (engine_ == "v8") {
-    expected_warm_time_ns = 20000000;
-    expected_warm_time_speedup_factor = 1.5;
+    expected_warm_time_ns = 30000000;
   } else if (engine_ == "wamr") {
-    expected_warm_time_ns = 4000;
-    expected_warm_time_speedup_factor = 2000;
+    expected_warm_time_ns = 10000;
   } else if (engine_ == "wasmedge") {
     expected_warm_time_ns = 2000;
-    expected_warm_time_speedup_factor = 1.5;
   } else if (engine_ == "wasmtime") {
     expected_warm_time_ns = 8000;
-    expected_warm_time_speedup_factor = 6;
   }
   // Linux 390x is significantly slower, so we use a more lenient limit.
 #if defined(__linux__) && defined(__s390x__)
-  expected_warm_time_ns *= 10;
+  expected_warm_time_ns *= 30;
 #endif
-#if defined(THREAD_SANITIZER) || defined(MEMORY_SANITIZER) || defined(ADDRESS_SANITIZER) ||        \
-    defined(HWADDRESS_SANITIZER) || defined(THREAD_SANITIZER)
-  expected_warm_time_ns *= 10;
-#else
-  EXPECT_LE(warm * expected_warm_time_speedup_factor, cold);
-#endif
+#if !defined(THREAD_SANITIZER) && !defined(MEMORY_SANITIZER) && !defined(ADDRESS_SANITIZER) &&     \
+    !defined(HWADDRESS_SANITIZER) && !defined(THREAD_SANITIZER)
   EXPECT_LT(warm, expected_warm_time_ns);
+#endif
 }
 
 TEST_P(TestVm, Basic) {

--- a/test/wasm_vm_test.cc
+++ b/test/wasm_vm_test.cc
@@ -188,32 +188,17 @@ void BM_WarmVmStart(benchmark::State &state, auto makeVm) {
     warm_vm->warm();
   }
 }
-#ifdef PROXY_WASM_HOST_ENGINE_V8
-static void BM_V8WarmVmStart(benchmark::State &state) {
-  BM_WarmVmStart(state, []() { return proxy_wasm::createV8Vm(); });
-}
-BENCHMARK(BM_V8WarmVmStart);
-#endif
-#ifdef PROXY_WASM_HOST_ENGINE_WASMTIME
-static void BM_WasmtimeWarmVmStart(benchmark::State &state) {
-  BM_WarmVmStart(state, []() { return proxy_wasm::createWasmtimeVm(); });
-}
-BENCHMARK(BM_WasmtimeWarmVmStart);
-#endif
-#ifdef PROXY_WASM_HOST_ENGINE_WASMEDGE
-static void BM_WasmEdgeWarmVmStart(benchmark::State &state) {
-  BM_WarmVmStart(state, []() { return proxy_wasm::createWasmEdgeVm(); });
-}
-BENCHMARK(BM_WasmEdgeWarmVmStart);
-#endif
-#ifdef PROXY_WASM_HOST_ENGINE_WAMR
-static void BM_WamrWarmVmStart(benchmark::State &state) {
-  BM_WarmVmStart(state, []() { return proxy_wasm::createWamrVm(); });
-}
-BENCHMARK(BM_WamrWarmVmStart);
-#endif
 
-TEST(TestVm, Benchmarks) { benchmark::RunSpecifiedBenchmarks(); }
+TEST(TestVm, Benchmarks) {
+  for (std::string engine : getWasmEngines()) {
+    benchmark::RegisterBenchmark(
+        "BM_WarmVmStart/" + engine,
+        [](benchmark::State &state, auto makeVm) { BM_WarmVmStart(state, makeVm); },
+        [engine]() { return TestVm::makeVm(engine); });
+  }
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+}
 
 } // namespace
 } // namespace proxy_wasm

--- a/test/wasm_vm_test.cc
+++ b/test/wasm_vm_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "gtest/gtest.h"
+#include "benchmark/benchmark.h"
 
 #include <memory>
 #include <string>
@@ -31,10 +32,12 @@ INSTANTIATE_TEST_SUITE_P(WasmEngines, TestVm, testing::ValuesIn(getWasmEngines()
                          });
 
 TEST_P(TestVm, Init) {
+  std::unique_ptr<WasmVm> vm1 = makeVm(engine_);
+  std::unique_ptr<WasmVm> vm2 = makeVm(engine_);
   auto time1 = std::chrono::steady_clock::now();
-  vm_->warm();
+  vm1->warm();
   auto time2 = std::chrono::steady_clock::now();
-  vm_->warm();
+  vm2->warm();
   auto time3 = std::chrono::steady_clock::now();
 
   auto cold = std::chrono::duration_cast<std::chrono::nanoseconds>(time2 - time1).count();
@@ -43,24 +46,37 @@ TEST_P(TestVm, Init) {
   std::cout << "[" << engine_ << "] \"cold\" engine time: " << cold << "ns" << std::endl;
   std::cout << "[" << engine_ << "] \"warm\" engine time: " << warm << "ns" << std::endl;
 
-  // Default warm time in nanoseconds.
-  int warm_time_ns_limit = 10000;
-
-#if defined(__linux__) && defined(__s390x__)
-  // Linux 390x is significantly slower, so we use a more lenient limit.
-  warm_time_ns_limit = 75000;
-#endif
-
-  // Verify that getting a "warm" engine takes less than 10us.
-  EXPECT_LE(warm, warm_time_ns_limit);
-
   // Verify that getting a "warm" engine takes at least 50x less time than getting a "cold" one.
   // We skip NullVM because warm() is a noop.
   if (engine_ == "null") {
     std::cout << "Skipping warm() performance assertions for NullVM." << std::endl;
     return;
   }
-  EXPECT_LE(warm * 50, cold);
+  int expected_warm_time_ns = 0;
+  double expected_warm_time_speedup_factor = 0;
+  if (engine_ == "v8") {
+    expected_warm_time_ns = 20000000;
+    expected_warm_time_speedup_factor = 1.5;
+  } else if (engine_ == "wamr") {
+    expected_warm_time_ns = 4000;
+    expected_warm_time_speedup_factor = 2000;
+  } else if (engine_ == "wasmedge") {
+    expected_warm_time_ns = 2000;
+    expected_warm_time_speedup_factor = 1.5;
+  } else if (engine_ == "wasmtime") {
+    expected_warm_time_ns = 8000;
+    expected_warm_time_speedup_factor = 6;
+  }
+  // Linux 390x is significantly slower, so we use a more lenient limit.
+#if defined(__linux__) && defined(__s390x__)
+  expected_warm_time_ns *= 10;
+#endif
+#if defined(THREAD_SANITIZER) || defined(MEMORY_SANITIZER) || defined(ADDRESS_SANITIZER) ||        \
+    defined(HWADDRESS_SANITIZER) || defined(THREAD_SANITIZER)
+  expected_warm_time_ns *= 10;
+#endif
+  EXPECT_LE(warm * expected_warm_time_speedup_factor, cold);
+  EXPECT_LT(warm, expected_warm_time_ns);
 }
 
 TEST_P(TestVm, Basic) {
@@ -163,6 +179,41 @@ TEST_P(TestVm, DISABLED_CloneUntilOutOfMemory) {
 }
 
 #endif
+
+void BM_WarmVmStart(benchmark::State &state, auto makeVm) {
+  std::unique_ptr<WasmVm> cold_vm = makeVm();
+  cold_vm->warm();
+  for (auto _ : state) {
+    std::unique_ptr<WasmVm> warm_vm = makeVm();
+    warm_vm->warm();
+  }
+}
+#ifdef PROXY_WASM_HOST_ENGINE_V8
+static void BM_V8WarmVmStart(benchmark::State &state) {
+  BM_WarmVmStart(state, []() { return proxy_wasm::createV8Vm(); });
+}
+BENCHMARK(BM_V8WarmVmStart);
+#endif
+#ifdef PROXY_WASM_HOST_ENGINE_WASMTIME
+static void BM_WasmtimeWarmVmStart(benchmark::State &state) {
+  BM_WarmVmStart(state, []() { return proxy_wasm::createWasmtimeVm(); });
+}
+BENCHMARK(BM_WasmtimeWarmVmStart);
+#endif
+#ifdef PROXY_WASM_HOST_ENGINE_WASMEDGE
+static void BM_WasmEdgeWarmVmStart(benchmark::State &state) {
+  BM_WarmVmStart(state, []() { return proxy_wasm::createWasmEdgeVm(); });
+}
+BENCHMARK(BM_WasmEdgeWarmVmStart);
+#endif
+#ifdef PROXY_WASM_HOST_ENGINE_WAMR
+static void BM_WamrWarmVmStart(benchmark::State &state) {
+  BM_WarmVmStart(state, []() { return proxy_wasm::createWamrVm(); });
+}
+BENCHMARK(BM_WamrWarmVmStart);
+#endif
+
+TEST(TestVm, Benchmarks) { benchmark::RunSpecifiedBenchmarks(); }
 
 } // namespace
 } // namespace proxy_wasm

--- a/test/wasm_vm_test.cc
+++ b/test/wasm_vm_test.cc
@@ -60,7 +60,7 @@ TEST_P(TestVm, Init) {
   } else if (engine_ == "wasmedge") {
     expected_warm_time_ns = 2000;
   } else if (engine_ == "wasmtime") {
-    expected_warm_time_ns = 8000;
+    expected_warm_time_ns = 20000;
   }
   // Linux 390x is significantly slower, so we use a more lenient limit.
 #if defined(__linux__) && defined(__s390x__)

--- a/test/wasm_vm_test.cc
+++ b/test/wasm_vm_test.cc
@@ -74,8 +74,9 @@ TEST_P(TestVm, Init) {
 #if defined(THREAD_SANITIZER) || defined(MEMORY_SANITIZER) || defined(ADDRESS_SANITIZER) ||        \
     defined(HWADDRESS_SANITIZER) || defined(THREAD_SANITIZER)
   expected_warm_time_ns *= 10;
-#endif
+#else
   EXPECT_LE(warm * expected_warm_time_speedup_factor, cold);
+#endif
   EXPECT_LT(warm, expected_warm_time_ns);
 }
 
@@ -190,6 +191,10 @@ void BM_WarmVmStart(benchmark::State &state, auto makeVm) {
 }
 
 TEST(TestVm, Benchmarks) {
+#if defined(THREAD_SANITIZER) || defined(MEMORY_SANITIZER) || defined(ADDRESS_SANITIZER) ||        \
+    defined(HWADDRESS_SANITIZER) || defined(THREAD_SANITIZER)
+  GTEST_SKIP() << "Disabled due to sanitizer.";
+#endif
   for (std::string engine : getWasmEngines()) {
     benchmark::RegisterBenchmark(
         "BM_WarmVmStart/" + engine,


### PR DESCRIPTION
Includes a microbenchmark to demonstrate the time it takes to create and warm a new WasmVm instance for each runtime, which was used to find the thresholds for the regression test.

I ran the regression test with many `--runs_per_test` to fine-tune the limits to avoid flakes.

Benchmark results with `--dynamic_mode=off -c opt`
```
Run on (128 X 2450 MHz CPU s)
-----------------------------------------------------------------
Benchmark                       Time             CPU   Iterations
-----------------------------------------------------------------
BM_V8WarmVmStart           535905 ns       535830 ns         1303
BM_WasmtimeWarmVmStart        372 ns          372 ns      1880324
BM_WasmEdgeWarmVmStart        235 ns          235 ns      2978325
BM_WamrWarmVmStart            181 ns          181 ns      3868665
```

In fastbuild:
```
Run on (128 X 2450 MHz CPU s)
***WARNING*** Library was built as DEBUG. Timings may be affected.
----------------------------------------------------------------- 
Benchmark                       Time             CPU   Iterations 
----------------------------------------------------------------- 
BM_V8WarmVmStart         13467098 ns     13464209 ns           51 
BM_WasmtimeWarmVmStart       6539 ns         6538 ns       106450 
BM_WasmEdgeWarmVmStart       1524 ns         1523 ns       457547 
BM_WamrWarmVmStart            859 ns          859 ns       801159
```