### PR TITLE
Add bytecode_util to wasm_vm_headers

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -36,6 +36,7 @@ filegroup(
 cc_library(
     name = "wasm_vm_headers",
     hdrs = [
+        "include/proxy-wasm/bytecode_util.h",
         "include/proxy-wasm/limits.h",
         "include/proxy-wasm/sdk.h",
         "include/proxy-wasm/wasm_vm.h",


### PR DESCRIPTION
This is to be used by all wasm_vm integrations for serialize(). This passed all tests because each test has a dependency on `:base_lib` already, but it does not satisfy IWYU.