### PR TITLE
fix: make WasmBase::doAfterVmCallActions reentry-safe (drain-to-local)

### DIFF
--- a/include/proxy-wasm/wasm.h
+++ b/include/proxy-wasm/wasm.h
@@ -147,9 +147,21 @@ public:
     // NB: this may be deleted by a delayed function unless prevented.
     if (!after_vm_call_actions_.empty()) {
       auto self = shared_from_this();
-      while (!self->after_vm_call_actions_.empty()) {
-        auto f = std::move(self->after_vm_call_actions_.front());
-        self->after_vm_call_actions_.pop_front();
+      // Swap the queue into a local before draining, then iterate the snapshot exactly
+      // once. Actions re-added by a callback during the drain land in the (now-empty)
+      // member queue and are picked up by the next-outer DeferAfterCallActions frame,
+      // instead of being re-run in this same loop. With the old unguarded
+      // `while (!empty())`, an action that (directly or transitively) re-enqueues during
+      // the drain -- e.g. a host call such as sendLocalReply/injectEncodedDataToFilterChain
+      // that synchronously re-enters the VM and schedules another after-VM-call action --
+      // means the loop never observes an empty queue and spins forever, pinning a CPU at
+      // 100%. Deferring re-added actions to the next-outer frame also prevents an action
+      // queued in one phase (e.g. continueStream from onRequestHeaders) from executing
+      // inside a nested VM call of a different phase (e.g. onResponseHeaders triggered by
+      // sendLocalReply); see proxy-wasm/proxy-wasm-cpp-host#326.
+      std::deque<std::function<void()>> local;
+      local.swap(self->after_vm_call_actions_);
+      for (auto &f : local) {
         f();
       }
     }

--- a/test/wasm_test.cc
+++ b/test/wasm_test.cc
@@ -324,4 +324,32 @@ TEST_P(TestVm, CleanupThreadLocalCacheKeys) {
   EXPECT_TRUE(stale_wasms_keys.empty());
 }
 
+// doAfterVmCallActions() must not spin forever when a queued action re-enqueues itself
+// during the drain. With the old unguarded `while (!empty())` loop this loops forever;
+// with the drain-to-local fix each call runs the snapshot exactly once and the re-added
+// copy is deferred to the next drain.
+TEST_P(TestVm, DoAfterVmCallActionsReentrySafe) {
+  // WasmBase::doAfterVmCallActions() calls shared_from_this(), so the instance must be
+  // owned by a std::shared_ptr (a stack WasmBase would crash).
+  auto wasm = std::make_shared<TestWasm>(makeVm(engine_));
+
+  int count = 0;
+  std::function<void()> f;
+  f = [&]() {
+    ++count;
+    // Re-enqueue self during the drain. Under the old code this would be picked up by the
+    // same loop and never terminate.
+    wasm->addAfterVmCallAction(f);
+  };
+
+  wasm->addAfterVmCallAction(f);
+  // Snapshot {f} runs exactly once; the re-added copy lands in the now-empty member queue.
+  wasm->doAfterVmCallActions();
+  EXPECT_EQ(count, 1); // Returns after one pass (the old while-loop would never return).
+
+  // The re-added copy runs on the next frame (and re-enqueues once more).
+  wasm->doAfterVmCallActions();
+  EXPECT_EQ(count, 2);
+}
+
 } // namespace proxy_wasm


### PR DESCRIPTION
## Problem

`WasmBase::doAfterVmCallActions()` drains its `after_vm_call_actions_` queue with an
unguarded `while (!after_vm_call_actions_.empty())` loop, popping and running one action
at a time:

```cpp
while (!self->after_vm_call_actions_.empty()) {
  auto f = std::move(self->after_vm_call_actions_.front());
  self->after_vm_call_actions_.pop_front();
  f();
}
```

If an action re-enqueues itself (or otherwise adds a new action) **during** the drain,
the freshly-added action is observed by the same loop and executed again in the same
frame. Under synchronous reentry this loop never sees an empty queue and spins forever,
pinning a worker at 100% CPU.

This is reachable from a plugin today. A host call made from within an after-VM-call
action re-enters the VM synchronously, and that nested VM call's `DeferAfterCallActions`
guard calls `doAfterVmCallActions()` again. For example, in the Envoy host, a deferred
`onRedisCall`/`onHttpCall` failure callback that calls
`injectEncodedDataToFilterChain` (or `sendLocalReply`) re-enters the VM and schedules
another after-VM-call action; the outer loop keeps observing a non-empty queue and never
returns.

The same shared-queue reentry is also the mechanism behind #326: an action queued in one
phase (e.g. `continueStream()` from `onRequestHeaders`) is drained by a **nested**
`doAfterVmCallActions()` belonging to a *different* phase (e.g. `onResponseHeaders`
triggered by `sendLocalReply`), so the action "escapes" into the wrong phase.

## Fix

Swap the member queue into a local `std::deque` before draining, then iterate the
snapshot exactly once:

```cpp
std::deque<std::function<void()>> local;
local.swap(self->after_vm_call_actions_);
for (auto &f : local) {
  f();
}
```

Actions re-added by a callback during the drain land in the (now-empty) member queue and
are therefore picked up by the next-outer `DeferAfterCallActions` frame, instead of being
re-run in this loop. This:

- Breaks the synchronous-reentry spin (bounded work per call).
- Prevents cross-phase action escape (the re-added action runs in the outer frame, not
  inside a nested VM call of another phase) — see #326.
- Preserves ordering semantics for legitimately deferred work; re-added actions are still
  executed, just deferred to the next-outer frame.

It is a header-only change to a small inline method, zero-ABI and transparent to plugins
(no signature or behavior change visible to Wasm modules).

## Test

Adds `TEST_P(TestVm, DoAfterVmCallActionsReentrySafe)` in `test/wasm_test.cc`, wired into
the existing `//test:wasm_test` target. It registers a self-re-enqueuing action and
asserts the count advances by exactly one per `doAfterVmCallActions()` call. On the old
code this test hangs forever (documenting the regression); with the fix each drain runs
the snapshot once and defers the re-added copy.

## Refs

- Fixes the reentry mechanism described in #326.
- Downstream context / real-world repro: higress-group/higress#4034 (worker CPU spin via a
  deferred Redis-failure callback that injects into the filter chain).
