### PR TITLE
wasmtime: add options for configuring between winch and cranelift

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -225,6 +225,7 @@ cc_library(
         ":base_lib",
         ":wasm_vm_headers",
         "@com_github_bytecodealliance_wasmtime//:wasmtime_lib",
+        "@com_google_absl//absl/base:no_destructor",
     ],
 )
 

--- a/bazel/cargo/wasmtime/Cargo.toml
+++ b/bazel/cargo/wasmtime/Cargo.toml
@@ -26,4 +26,4 @@ path = "fake_lib.rs"
 [dependencies]
 # Fixes testdata build error due to missing crate_features = ["std"]
 log = {version = "0.4.29", default-features = false, features = ['std']}
-wasmtime-c-api-impl = {version = "45.0.2", default-features = false, features = ['cranelift', 'gc-drc']}
+wasmtime-c-api-impl = {version = "45.0.2", default-features = false, features = ['cranelift', 'winch', 'gc-drc']}

--- a/bazel/cargo/wasmtime/remote/BUILD.target-lexicon-0.13.5.bazel
+++ b/bazel/cargo/wasmtime/remote/BUILD.target-lexicon-0.13.5.bazel
@@ -40,6 +40,7 @@ rust_library(
     ),
     crate_features = [
         "default",
+        "std",
     ],
     crate_root = "src/lib.rs",
     edition = "2018",
@@ -83,6 +84,7 @@ cargo_build_script(
     ),
     crate_features = [
         "default",
+        "std",
     ],
     crate_name = "build_script_build",
     crate_root = "build.rs",

--- a/bazel/cargo/wasmtime/remote/BUILD.wasmtime-45.0.2.bazel
+++ b/bazel/cargo/wasmtime/remote/BUILD.wasmtime-45.0.2.bazel
@@ -32,6 +32,7 @@ rust_library(
         "@cu__wasmtime-internal-jit-icache-coherence-45.0.2//:wasmtime_internal_jit_icache_coherence": "wasmtime_jit_icache_coherence",
         "@cu__wasmtime-internal-unwinder-45.0.2//:wasmtime_internal_unwinder": "wasmtime_unwinder",
         "@cu__wasmtime-internal-versioned-export-macros-45.0.2//:wasmtime_internal_versioned_export_macros": "wasmtime_versioned_export_macros",
+        "@cu__wasmtime-internal-winch-45.0.2//:wasmtime_internal_winch": "wasmtime_winch",
     },
     compile_data = glob(
         include = ["**"],
@@ -53,6 +54,7 @@ rust_library(
         "runtime",
         "std",
         "wasmtime-jit-icache-coherence",
+        "winch",
     ],
     crate_root = "src/lib.rs",
     edition = "2024",
@@ -95,6 +97,7 @@ rust_library(
         "@cu__wasmtime-internal-cranelift-45.0.2//:wasmtime_internal_cranelift",
         "@cu__wasmtime-internal-jit-icache-coherence-45.0.2//:wasmtime_internal_jit_icache_coherence",
         "@cu__wasmtime-internal-unwinder-45.0.2//:wasmtime_internal_unwinder",
+        "@cu__wasmtime-internal-winch-45.0.2//:wasmtime_internal_winch",
     ] + select({
         "@rules_rust//rust/platform:aarch64-apple-darwin": [
             "@cu__mach2-0.4.2//:mach2",  # aarch64-apple-darwin
@@ -237,6 +240,7 @@ cargo_build_script(
         "runtime",
         "std",
         "wasmtime-jit-icache-coherence",
+        "winch",
     ],
     crate_name = "build_script_build",
     crate_root = "build.rs",

--- a/bazel/cargo/wasmtime/remote/BUILD.wasmtime-c-api-impl-45.0.2.bazel
+++ b/bazel/cargo/wasmtime/remote/BUILD.wasmtime-c-api-impl-45.0.2.bazel
@@ -44,6 +44,7 @@ rust_library(
     crate_features = [
         "cranelift",
         "gc-drc",
+        "winch",
     ],
     crate_root = "src/lib.rs",
     edition = "2024",
@@ -94,6 +95,7 @@ cargo_build_script(
     crate_features = [
         "cranelift",
         "gc-drc",
+        "winch",
     ],
     crate_name = "build_script_build",
     crate_root = "build.rs",

--- a/bazel/cargo/wasmtime/remote/BUILD.wasmtime-internal-winch-45.0.2.bazel
+++ b/bazel/cargo/wasmtime/remote/BUILD.wasmtime-internal-winch-45.0.2.bazel
@@ -37,6 +37,10 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
+    crate_features = [
+        "gc",
+        "gc-drc",
+    ],
     crate_root = "src/lib.rs",
     edition = "2024",
     rustc_env_files = [

--- a/bazel/cargo/wasmtime/remote/BUILD.winch-codegen-45.0.2.bazel
+++ b/bazel/cargo/wasmtime/remote/BUILD.winch-codegen-45.0.2.bazel
@@ -42,6 +42,10 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
+    crate_features = [
+        "gc",
+        "gc-drc",
+    ],
     crate_root = "src/lib.rs",
     edition = "2024",
     rustc_env_files = [
@@ -93,6 +97,10 @@ cargo_build_script(
             "WORKSPACE.bazel",
         ],
     ),
+    crate_features = [
+        "gc",
+        "gc-drc",
+    ],
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/bazel/external/wasmtime.BUILD
+++ b/bazel/external/wasmtime.BUILD
@@ -64,6 +64,7 @@ genrule(
 # will result in compile/link time failures.
 features = [
     "cranelift",
+    "winch",
     "gc-drc",
     # The C API of Wasmtime references the "gc" feature whenever cranelift is turned on.
     # Without adding `gc` to the headers, the C++ API will fail at compile time.

--- a/include/proxy-wasm/wasmtime.h
+++ b/include/proxy-wasm/wasmtime.h
@@ -44,7 +44,7 @@ struct WasmtimeEngineOptions {
   WasmtimeCompiler compiler = WasmtimeCompiler::kWinch;
   WasmtimeOptLevel opt_level = WasmtimeOptLevel::kNone;
 
-  bool operator==(const WasmtimeEngineOptions& rhs) const = default;
+  bool operator==(const WasmtimeEngineOptions &rhs) const = default;
 };
 
 struct WasmtimeOptions {

--- a/include/proxy-wasm/wasmtime.h
+++ b/include/proxy-wasm/wasmtime.h
@@ -30,9 +30,26 @@ enum class WasmtimeCompiler {
   kWinch,
 };
 
+enum class WasmtimeOptLevel {
+  // Turns off most optimizations (default).
+  kNone,
+  // Generates the fastest possible code.
+  kSpeed,
+  // Like speed, but also performs passes to optimize the size of the generated binary.
+  kSpeedAndSize,
+};
+
+// Options to configure the wasmtime engine.
+struct WasmtimeEngineOptions {
+  WasmtimeCompiler compiler = WasmtimeCompiler::kWinch;
+  WasmtimeOptLevel opt_level = WasmtimeOptLevel::kNone;
+
+  bool operator==(const WasmtimeEngineOptions& rhs) const = default;
+};
+
 struct WasmtimeOptions {
   uint64_t max_wasm_memory_size_bytes = PROXY_WASM_HOST_MAX_WASM_MEMORY_SIZE_BYTES;
-  WasmtimeCompiler compiler = WasmtimeCompiler::kWinch;
+  WasmtimeEngineOptions engine_options = {};
 };
 
 std::unique_ptr<WasmVm> createWasmtimeVm(WasmtimeOptions options = {});

--- a/include/proxy-wasm/wasmtime.h
+++ b/include/proxy-wasm/wasmtime.h
@@ -30,26 +30,9 @@ enum class WasmtimeCompiler {
   kWinch,
 };
 
-enum class WasmtimeOptLevel {
-  // Turns off most optimizations (default).
-  kNone,
-  // Generates the fastest possible code.
-  kSpeed,
-  // Like speed, but also performs passes to optimize the size of the generated binary.
-  kSpeedAndSize,
-};
-
-// Options to configure the wasmtime engine.
-struct WasmtimeEngineOptions {
-  WasmtimeCompiler compiler = WasmtimeCompiler::kCranelift;
-  WasmtimeOptLevel opt_level = WasmtimeOptLevel::kNone;
-
-  bool operator==(const WasmtimeEngineOptions &rhs) const = default;
-};
-
 struct WasmtimeOptions {
   uint64_t max_wasm_memory_size_bytes = PROXY_WASM_HOST_MAX_WASM_MEMORY_SIZE_BYTES;
-  WasmtimeEngineOptions engine_options = {};
+  WasmtimeCompiler compiler = WasmtimeCompiler::kCranelift;
 };
 
 std::unique_ptr<WasmVm> createWasmtimeVm(WasmtimeOptions options = {});

--- a/include/proxy-wasm/wasmtime.h
+++ b/include/proxy-wasm/wasmtime.h
@@ -14,13 +14,25 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "include/proxy-wasm/wasm_vm.h"
 #include "include/proxy-wasm/limits.h"
 
 namespace proxy_wasm {
 
+enum class WasmtimeCompiler {
+  // Optimizing compiler for Wasmtime. Performs optimizations during loading,
+  // which results in faster execution at the expense of load time.
+  kCranelift,
+  // Fast baseline compiler for Wasmtime. Does not perform optimizations, but
+  // loads plugins faster.
+  kWinch,
+};
+
 struct WasmtimeOptions {
   uint64_t max_wasm_memory_size_bytes = PROXY_WASM_HOST_MAX_WASM_MEMORY_SIZE_BYTES;
+  WasmtimeCompiler compiler = WasmtimeCompiler::kWinch;
 };
 
 std::unique_ptr<WasmVm> createWasmtimeVm(WasmtimeOptions options = {});

--- a/include/proxy-wasm/wasmtime.h
+++ b/include/proxy-wasm/wasmtime.h
@@ -41,7 +41,7 @@ enum class WasmtimeOptLevel {
 
 // Options to configure the wasmtime engine.
 struct WasmtimeEngineOptions {
-  WasmtimeCompiler compiler = WasmtimeCompiler::kWinch;
+  WasmtimeCompiler compiler = WasmtimeCompiler::kCranelift;
   WasmtimeOptLevel opt_level = WasmtimeOptLevel::kNone;
 
   bool operator==(const WasmtimeEngineOptions &rhs) const = default;

--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -59,13 +59,19 @@ using ::wasmtime::Store;
 using ::wasmtime::Table;
 using ::wasmtime::TrapResult;
 
-Engine *engine() {
-  static auto *const engine = []() {
-    Config config;
-    config.epoch_interruption(true);
-    return new Engine(std::move(config));
-  }();
-  return engine;
+Engine *engine(WasmtimeOptions &options) {
+  static std::mutex engines_mutex;
+  std::lock_guard<std::mutex> guard(engines_mutex);
+  static std::unordered_map<WasmtimeCompiler, Engine *> engines;
+  Engine *&engine = engines[options.compiler];
+  if (engine != nullptr) {
+    return engine;
+  }
+  Config config;
+  config.epoch_interruption(true);
+  config.strategy(options.compiler == WasmtimeCompiler::kCranelift ? ::wasmtime::Strategy::Cranelift
+                                                                   : ::wasmtime::Strategy::Winch);
+  return engine = new Engine(std::move(config));
 }
 
 template <typename T> std::string printValue(const T &value) { return std::to_string(value); }
@@ -95,7 +101,8 @@ void InPlaceConvertHostToWasmEndianness(auto &...args) {
 
 class Wasmtime : public WasmVm {
 public:
-  Wasmtime(WasmtimeOptions options) : options_(std::move(options)) {}
+  Wasmtime(WasmtimeOptions options)
+      : engine_(engine(options)), options_(std::move(options)), linker_(*engine_) {}
 
   std::string_view getEngineName() override { return "wasmtime"; }
   Cloneable cloneable() override { return Cloneable::CompiledBytecode; }
@@ -130,7 +137,7 @@ public:
 
   void warm() override;
 
-  void terminate() override { engine()->increment_epoch(); }
+  void terminate() override { engine_->increment_epoch(); }
 
   bool usesWasmByteOrder() override { return true; }
 
@@ -154,12 +161,13 @@ private:
   // Initialize the Wasmtime store if necessary.
   void initStore();
 
+  Engine *engine_;
   std::optional<Store> store_;
   std::optional<Module> module_;
   std::optional<Instance> instance_;
   std::optional<Memory> memory_;
   std::optional<Table> table_;
-  Linker linker_ = Linker(*engine());
+  Linker linker_;
 
   std::unordered_map<std::string, ::wasmtime::Func> module_functions_;
 
@@ -170,7 +178,7 @@ void Wasmtime::initStore() {
   if (store_.has_value()) {
     return;
   }
-  store_.emplace(*engine());
+  store_.emplace(*engine_);
   store_->limiter(options_.max_wasm_memory_size_bytes,
                   /*table_elements=*/10000,
                   /*instances=*/1,
@@ -188,8 +196,8 @@ bool Wasmtime::load(std::string_view bytecode, std::string_view precompiled,
   // Error message used if both precompiled and bytecode are empty.
   Result<Module> module(::wasmtime::Error("Unable to load Wasm module: empty"));
   if (!precompiled.empty()) {
-    module = Module::deserialize(*engine(),
-                                 std::span((uint8_t *)precompiled.data(), precompiled.size()));
+    module =
+        Module::deserialize(*engine_, std::span((uint8_t *)precompiled.data(), precompiled.size()));
     if (module) {
       module_.emplace(module.ok());
       return true;
@@ -200,7 +208,7 @@ bool Wasmtime::load(std::string_view bytecode, std::string_view precompiled,
          "Failed to deserialize Wasm module: " + module.err().message());
     return false;
   }
-  module = Module::compile(*engine(), std::span((uint8_t *)bytecode.data(), bytecode.size()));
+  module = Module::compile(*engine_, std::span((uint8_t *)bytecode.data(), bytecode.size()));
   if (!module) {
     fail(FailState::UnableToInitializeCode,
          "Failed to load Wasm module: " + module.err().message());
@@ -231,7 +239,7 @@ std::unique_ptr<WasmVm> Wasmtime::clone() {
     return nullptr;
   }
 
-  clone->store_.emplace(Store(*engine()));
+  clone->store_.emplace(Store(*engine_));
   clone->store_->limiter(options_.max_wasm_memory_size_bytes,
                          /*table_elements=*/10000,
                          /*instances=*/1,

--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -59,19 +59,38 @@ using ::wasmtime::Store;
 using ::wasmtime::Table;
 using ::wasmtime::TrapResult;
 
-Engine *engine(WasmtimeOptions &options) {
+struct EngineWithOpts {
+  Engine *engine;
+  WasmtimeEngineOptions options;
+};
+
+Engine *engine(WasmtimeEngineOptions &options) {
   static std::mutex engines_mutex;
   std::lock_guard<std::mutex> guard(engines_mutex);
-  static std::unordered_map<WasmtimeCompiler, Engine *> engines;
-  Engine *&engine = engines[options.compiler];
-  if (engine != nullptr) {
-    return engine;
+  static std::vector<EngineWithOpts> engines;
+  for (const auto &engine_with_opts : engines) {
+    if (engine_with_opts.options == options) {
+      return engine_with_opts.engine;
+    }
   }
   Config config;
   config.epoch_interruption(true);
   config.strategy(options.compiler == WasmtimeCompiler::kCranelift ? ::wasmtime::Strategy::Cranelift
                                                                    : ::wasmtime::Strategy::Winch);
-  return engine = new Engine(std::move(config));
+  switch (options.opt_level) {
+  case WasmtimeOptLevel::kNone:
+    config.cranelift_opt_level(::wasmtime::OptLevel::None);
+    break;
+  case WasmtimeOptLevel::kSpeed:
+    config.cranelift_opt_level(::wasmtime::OptLevel::Speed);
+    break;
+  case WasmtimeOptLevel::kSpeedAndSize:
+    config.cranelift_opt_level(::wasmtime::OptLevel::SpeedAndSize);
+    break;
+  }
+  Engine *engine = new Engine(std::move(config));
+  engines.push_back({.engine = engine, .options = options});
+  return engine;
 }
 
 template <typename T> std::string printValue(const T &value) { return std::to_string(value); }
@@ -102,7 +121,7 @@ void InPlaceConvertHostToWasmEndianness(auto &...args) {
 class Wasmtime : public WasmVm {
 public:
   Wasmtime(WasmtimeOptions options)
-      : engine_(engine(options)), options_(std::move(options)), linker_(*engine_) {}
+      : options_(std::move(options)), engine_(engine(options_.engine_options)), linker_(*engine_) {}
 
   std::string_view getEngineName() override { return "wasmtime"; }
   Cloneable cloneable() override { return Cloneable::CompiledBytecode; }
@@ -161,6 +180,7 @@ private:
   // Initialize the Wasmtime store if necessary.
   void initStore();
 
+  WasmtimeOptions options_;
   Engine *engine_;
   std::optional<Store> store_;
   std::optional<Module> module_;
@@ -170,8 +190,6 @@ private:
   Linker linker_;
 
   std::unordered_map<std::string, ::wasmtime::Func> module_functions_;
-
-  WasmtimeOptions options_;
 };
 
 void Wasmtime::initStore() {

--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -26,6 +26,7 @@
 #include "include/proxy-wasm/word.h"
 #include "include/proxy-wasm/bytecode_util.h"
 
+#include "absl/base/no_destructor.h"
 #include "crates/c-api/include/wasmtime.h"  // IWYU pragma: keep
 #include "crates/c-api/include/wasmtime.hh" // IWYU pragma: keep
 
@@ -60,17 +61,17 @@ using ::wasmtime::Table;
 using ::wasmtime::TrapResult;
 
 struct EngineWithOpts {
-  Engine *engine;
+  std::unique_ptr<Engine> engine;
   WasmtimeEngineOptions options;
 };
 
 Engine *engine(WasmtimeEngineOptions &options) {
-  static std::mutex engines_mutex;
-  std::lock_guard<std::mutex> guard(engines_mutex);
-  static std::vector<EngineWithOpts> engines;
-  for (const auto &engine_with_opts : engines) {
+  static absl::NoDestructor<std::mutex> engines_mutex;
+  std::lock_guard<std::mutex> guard(*engines_mutex);
+  static absl::NoDestructor<std::vector<EngineWithOpts>> engines;
+  for (auto &engine_with_opts : *engines) {
     if (engine_with_opts.options == options) {
-      return engine_with_opts.engine;
+      return engine_with_opts.engine.get();
     }
   }
   Config config;
@@ -88,9 +89,8 @@ Engine *engine(WasmtimeEngineOptions &options) {
     config.cranelift_opt_level(::wasmtime::OptLevel::SpeedAndSize);
     break;
   }
-  Engine *engine = new Engine(std::move(config));
-  engines.push_back({.engine = engine, .options = options});
-  return engine;
+  engines->emplace_back(std::make_unique<Engine>(std::move(config)), options);
+  return engines->back().engine.get();
 }
 
 template <typename T> std::string printValue(const T &value) { return std::to_string(value); }

--- a/src/wasmtime/wasmtime.cc
+++ b/src/wasmtime/wasmtime.cc
@@ -60,37 +60,24 @@ using ::wasmtime::Store;
 using ::wasmtime::Table;
 using ::wasmtime::TrapResult;
 
-struct EngineWithOpts {
-  std::unique_ptr<Engine> engine;
-  WasmtimeEngineOptions options;
-};
-
-Engine *engine(WasmtimeEngineOptions &options) {
+Engine *engine(WasmtimeOptions &options) {
   static absl::NoDestructor<std::mutex> engines_mutex;
   std::lock_guard<std::mutex> guard(*engines_mutex);
-  static absl::NoDestructor<std::vector<EngineWithOpts>> engines;
-  for (auto &engine_with_opts : *engines) {
-    if (engine_with_opts.options == options) {
-      return engine_with_opts.engine.get();
-    }
+  static absl::NoDestructor<std::unordered_map<WasmtimeCompiler, std::unique_ptr<Engine>>> engines;
+  std::unique_ptr<Engine> &engine = (*engines)[options.compiler];
+  if (engine != nullptr) {
+    return engine.get();
   }
   Config config;
   config.epoch_interruption(true);
-  config.strategy(options.compiler == WasmtimeCompiler::kCranelift ? ::wasmtime::Strategy::Cranelift
-                                                                   : ::wasmtime::Strategy::Winch);
-  switch (options.opt_level) {
-  case WasmtimeOptLevel::kNone:
-    config.cranelift_opt_level(::wasmtime::OptLevel::None);
-    break;
-  case WasmtimeOptLevel::kSpeed:
-    config.cranelift_opt_level(::wasmtime::OptLevel::Speed);
-    break;
-  case WasmtimeOptLevel::kSpeedAndSize:
+  if (options.compiler == WasmtimeCompiler::kCranelift) {
+    config.strategy(::wasmtime::Strategy::Cranelift);
     config.cranelift_opt_level(::wasmtime::OptLevel::SpeedAndSize);
-    break;
+  } else {
+    config.strategy(::wasmtime::Strategy::Winch);
   }
-  engines->emplace_back(std::make_unique<Engine>(std::move(config)), options);
-  return engines->back().engine.get();
+  engine = std::make_unique<Engine>(std::move(config));
+  return engine.get();
 }
 
 template <typename T> std::string printValue(const T &value) { return std::to_string(value); }
@@ -121,7 +108,7 @@ void InPlaceConvertHostToWasmEndianness(auto &...args) {
 class Wasmtime : public WasmVm {
 public:
   Wasmtime(WasmtimeOptions options)
-      : options_(std::move(options)), engine_(engine(options_.engine_options)), linker_(*engine_) {}
+      : options_(std::move(options)), engine_(engine(options_)), linker_(*engine_) {}
 
   std::string_view getEngineName() override { return "wasmtime"; }
   Cloneable cloneable() override { return Cloneable::CompiledBytecode; }

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -219,10 +219,9 @@ TEST_P(TestVm, WasmtimeCompilerOption) {
   // s390x does not currently support Winch.
   return;
 #endif
-  auto cranelift_vm =
-      createWasmtimeVm({.engine_options = {.compiler = WasmtimeCompiler::kCranelift}});
+  auto cranelift_vm = createWasmtimeVm({.compiler = WasmtimeCompiler::kCranelift});
   cranelift_vm->integration() = std::make_unique<TestIntegration>();
-  auto winch_vm = createWasmtimeVm({.engine_options = {.compiler = WasmtimeCompiler::kWinch}});
+  auto winch_vm = createWasmtimeVm({.compiler = WasmtimeCompiler::kWinch});
   winch_vm->integration() = std::make_unique<TestIntegration>();
   auto source = readTestWasmFile("clock.wasm");
   ASSERT_FALSE(source.empty());
@@ -239,30 +238,6 @@ TEST_P(TestVm, WasmtimeCompilerOption) {
   std::chrono::duration cranelift_load_time = t2 - t1;
   // Winch should be significantly faster the load than cranelift.
   EXPECT_LT(winch_load_time, cranelift_load_time);
-}
-
-TEST_P(TestVm, WasmtimeOptLevelOption) {
-  if (engine_ != "wasmtime") {
-    return;
-  }
-  auto none_vm = createWasmtimeVm({.engine_options = {.compiler = WasmtimeCompiler::kCranelift,
-                                                      .opt_level = WasmtimeOptLevel::kNone}});
-  none_vm->integration() = std::make_unique<TestIntegration>();
-  auto opt_vm =
-      createWasmtimeVm({.engine_options = {.compiler = WasmtimeCompiler::kCranelift,
-                                           .opt_level = WasmtimeOptLevel::kSpeedAndSize}});
-  opt_vm->integration() = std::make_unique<TestIntegration>();
-  auto source = readTestWasmFile("clock.wasm");
-  ASSERT_FALSE(source.empty());
-  auto none_wasm = TestWasm(std::move(none_vm));
-  auto opt_wasm = TestWasm(std::move(opt_vm));
-
-  ASSERT_TRUE(none_wasm.load(source, false));
-  ASSERT_TRUE(opt_wasm.load(source, false));
-
-  std::optional<std::string> none_binary = none_wasm.wasm_vm()->serialize(source);
-  std::optional<std::string> opt_binary = opt_wasm.wasm_vm()->serialize(source);
-  EXPECT_LT(opt_binary->size(), none_binary->size());
 }
 #endif
 

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -215,12 +215,12 @@ TEST_P(TestVm, WasmtimeCompilerOption) {
   if (engine_ != "wasmtime") {
     return;
   }
+  auto cranelift_vm = createWasmtimeVm({.compiler = WasmtimeCompiler::kCranelift});
+  cranelift_vm->integration() = std::make_unique<TestIntegration>();
 #ifdef __s390x__
   // s390x does not currently support Winch.
   return;
 #endif
-  auto cranelift_vm = createWasmtimeVm({.compiler = WasmtimeCompiler::kCranelift});
-  cranelift_vm->integration() = std::make_unique<TestIntegration>();
   auto winch_vm = createWasmtimeVm({.compiler = WasmtimeCompiler::kWinch});
   winch_vm->integration() = std::make_unique<TestIntegration>();
   auto source = readTestWasmFile("clock.wasm");
@@ -236,8 +236,8 @@ TEST_P(TestVm, WasmtimeCompilerOption) {
 
   std::chrono::duration winch_load_time = t3 - t2;
   std::chrono::duration cranelift_load_time = t2 - t1;
-  // Winch should be significantly faster the load than cranelift.
-  EXPECT_LT(winch_load_time, cranelift_load_time);
+  // Winch should be significantly (5x) faster to load than cranelift.
+  EXPECT_LT(winch_load_time * 3, cranelift_load_time);
 }
 #endif
 

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -211,13 +211,14 @@ TEST_P(TestVm, WasmMemoryLimitCustomOption) {
   EXPECT_TRUE(host->isErrorLogged("unreachable"));
 }
 
-TEST_P(TestVm, WasmtimeCompiler) {
+TEST_P(TestVm, WasmtimeCompilerOption) {
   if (engine_ != "wasmtime") {
     return;
   }
-  auto cranelift_vm = createWasmtimeVm({.compiler = WasmtimeCompiler::kCranelift});
+  auto cranelift_vm =
+      createWasmtimeVm({.engine_options = {.compiler = WasmtimeCompiler::kCranelift}});
   cranelift_vm->integration() = std::make_unique<TestIntegration>();
-  auto winch_vm = createWasmtimeVm({.compiler = WasmtimeCompiler::kWinch});
+  auto winch_vm = createWasmtimeVm({.engine_options = {.compiler = WasmtimeCompiler::kWinch}});
   winch_vm->integration() = std::make_unique<TestIntegration>();
   auto source = readTestWasmFile("clock.wasm");
   ASSERT_FALSE(source.empty());
@@ -234,6 +235,30 @@ TEST_P(TestVm, WasmtimeCompiler) {
   std::chrono::duration cranelift_load_time = t2 - t1;
   // Winch should be significantly faster the load than cranelift.
   EXPECT_LT(winch_load_time, cranelift_load_time);
+}
+
+TEST_P(TestVm, WasmtimeOptLevelOption) {
+  if (engine_ != "wasmtime") {
+    return;
+  }
+  auto none_vm = createWasmtimeVm({.engine_options = {.compiler = WasmtimeCompiler::kCranelift,
+                                                      .opt_level = WasmtimeOptLevel::kNone}});
+  none_vm->integration() = std::make_unique<TestIntegration>();
+  auto opt_vm =
+      createWasmtimeVm({.engine_options = {.compiler = WasmtimeCompiler::kCranelift,
+                                           .opt_level = WasmtimeOptLevel::kSpeedAndSize}});
+  opt_vm->integration() = std::make_unique<TestIntegration>();
+  auto source = readTestWasmFile("clock.wasm");
+  ASSERT_FALSE(source.empty());
+  auto none_wasm = TestWasm(std::move(none_vm));
+  auto opt_wasm = TestWasm(std::move(opt_vm));
+
+  ASSERT_TRUE(none_wasm.load(source, false));
+  ASSERT_TRUE(opt_wasm.load(source, false));
+
+  std::optional<std::string> none_binary = none_wasm.wasm_vm()->serialize(source);
+  std::optional<std::string> opt_binary = opt_wasm.wasm_vm()->serialize(source);
+  EXPECT_LT(opt_binary->size(), none_binary->size());
 }
 #endif
 

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -210,6 +210,31 @@ TEST_P(TestVm, WasmMemoryLimitCustomOption) {
   EXPECT_TRUE(host->isErrorLogged("Function: infinite_memory failed"));
   EXPECT_TRUE(host->isErrorLogged("unreachable"));
 }
+
+TEST_P(TestVm, WasmtimeCompiler) {
+  if (engine_ != "wasmtime") {
+    return;
+  }
+  auto cranelift_vm = createWasmtimeVm({.compiler = WasmtimeCompiler::kCranelift});
+  cranelift_vm->integration() = std::make_unique<TestIntegration>();
+  auto winch_vm = createWasmtimeVm({.compiler = WasmtimeCompiler::kWinch});
+  winch_vm->integration() = std::make_unique<TestIntegration>();
+  auto source = readTestWasmFile("clock.wasm");
+  ASSERT_FALSE(source.empty());
+  auto cranelift_wasm = TestWasm(std::move(cranelift_vm));
+  auto winch_wasm = TestWasm(std::move(winch_vm));
+
+  auto t1 = std::chrono::steady_clock::now();
+  ASSERT_TRUE(cranelift_wasm.load(source, false));
+  auto t2 = std::chrono::steady_clock::now();
+  ASSERT_TRUE(winch_wasm.load(source, false));
+  auto t3 = std::chrono::steady_clock::now();
+
+  std::chrono::duration winch_load_time = t3 - t2;
+  std::chrono::duration cranelift_load_time = t2 - t1;
+  // Winch should be significantly faster the load than cranelift.
+  EXPECT_LT(winch_load_time, cranelift_load_time);
+}
 #endif
 
 TEST_P(TestVm, Trap) {

--- a/test/runtime_test.cc
+++ b/test/runtime_test.cc
@@ -215,6 +215,10 @@ TEST_P(TestVm, WasmtimeCompilerOption) {
   if (engine_ != "wasmtime") {
     return;
   }
+#ifdef __s390x__
+  // s390x does not currently support Winch.
+  return;
+#endif
   auto cranelift_vm =
       createWasmtimeVm({.engine_options = {.compiler = WasmtimeCompiler::kCranelift}});
   cranelift_vm->integration() = std::make_unique<TestIntegration>();


### PR DESCRIPTION
<img width="2542" height="933" alt="image" src="https://github.com/user-attachments/assets/55be9c58-7d3d-4cb8-b339-778a39ed88c6" />

Winch has significantly faster load times than cranelift, with negligible difference in runtime performance:

<img width="2098" height="854" alt="image" src="https://github.com/user-attachments/assets/99039488-5d4f-4609-a297-97ddbfd2b645" />

With this change, we will be ready to switch Envoy over to using Wasmtime with Winch by default.